### PR TITLE
Unintrusive workaround for rust-lang/rust#22776.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,8 +265,9 @@ macro_rules! write_num_bytes {
 
         assert!($dst.len() >= $size); // critical for memory safety!
         unsafe {
-            let bytes = (&transmute::<_, [u8; $size]>($n.$which())).as_ptr();
-            copy_nonoverlapping_memory($dst.as_mut_ptr(), bytes, $size);
+            // n.b. https://github.com/rust-lang/rust/issues/22776
+            let bytes = transmute::<_, [u8; $size]>($n.$which());
+            copy_nonoverlapping_memory($dst.as_mut_ptr(), (&bytes).as_ptr(), $size);
         }
     });
 }


### PR DESCRIPTION
Even though this looks like a compiler issue with optimisations, I hereby propose the patch mentioned in rust-lang/rust#22776 as an unintrusive (temporary) workaround, since cross-compiling `byteorder` to Android ARM with optimisations is broken otherwise and the issue can be difficult to diagnose.