### PR TITLE
Check at the same time the beta and the nightly on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: rust
+
+rust:
+    - 1.0.0-beta.2
+    - nightly


### PR DESCRIPTION
Commit https://github.com/BurntSushi/byteorder/commit/b8d12248946fcac08239373551fc48abe72b9ace broke this crate on beta 1.
To prevent accidental mistakes, I suggest to test both the beta and the nightly on travis.
