### PR TITLE
Allow builds without std dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,8 @@ name = "byteorder"
 quickcheck = "0.2"
 rand = "0.3"
 
+[features]
+no-std = []
+
 [profile.bench]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,10 @@ assert_eq!(wtr, vec![5, 2, 0, 3]);
 
 use std::mem::transmute;
 
+#[cfg(not(feature = "no-std"))]
 pub use new::{ReadBytesExt, WriteBytesExt, Error, Result};
 
+#[cfg(not(feature = "no-std"))]
 mod new;
 
 #[inline]


### PR DESCRIPTION
It is behind feature so it won't affect current users, but allow others to remove dependency when not needed.