### PR TITLE
Remove custom error type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use std::mem::transmute;
 use std::ptr::copy_nonoverlapping;
 
 #[cfg(not(feature = "no-std"))]
-pub use new::{ReadBytesExt, WriteBytesExt, Error, Result};
+pub use new::{ReadBytesExt, WriteBytesExt};
 
 #[cfg(not(feature = "no-std"))]
 mod new;

--- a/src/new.rs
+++ b/src/new.rs
@@ -130,10 +130,6 @@ pub trait ReadBytesExt: io::Read {
 /// for free.
 impl<R: io::Read + ?Sized> ReadBytesExt for R {}
 
-fn write_all<W: io::Write + ?Sized>(wtr: &mut W, buf: &[u8]) -> Result<()> {
-    wtr.write_all(buf).map_err(From::from)
-}
-
 /// Extends `Write` with methods for writing numbers. (For `std::io`.)
 ///
 /// Most of the methods defined here have an unconstrained type parameter that
@@ -159,7 +155,7 @@ pub trait WriteBytesExt: io::Write {
     /// are used. It is included for completeness.
     #[inline]
     fn write_u8(&mut self, n: u8) -> Result<()> {
-        write_all(self, &[n])
+        self.write_all(&[n])
     }
 
     /// Writes a signed 8 bit integer to the underlying writer.
@@ -168,7 +164,7 @@ pub trait WriteBytesExt: io::Write {
     /// are used. It is included for completeness.
     #[inline]
     fn write_i8(&mut self, n: i8) -> Result<()> {
-        write_all(self, &[n as u8])
+        self.write_all(&[n as u8])
     }
 
     /// Writes an unsigned 16 bit integer to the underlying writer.
@@ -176,7 +172,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_u16<T: ByteOrder>(&mut self, n: u16) -> Result<()> {
         let mut buf = [0; 2];
         T::write_u16(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes a signed 16 bit integer to the underlying writer.
@@ -184,7 +180,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_i16<T: ByteOrder>(&mut self, n: i16) -> Result<()> {
         let mut buf = [0; 2];
         T::write_i16(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes an unsigned 32 bit integer to the underlying writer.
@@ -192,7 +188,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_u32<T: ByteOrder>(&mut self, n: u32) -> Result<()> {
         let mut buf = [0; 4];
         T::write_u32(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes a signed 32 bit integer to the underlying writer.
@@ -200,7 +196,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_i32<T: ByteOrder>(&mut self, n: i32) -> Result<()> {
         let mut buf = [0; 4];
         T::write_i32(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes an unsigned 64 bit integer to the underlying writer.
@@ -208,7 +204,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_u64<T: ByteOrder>(&mut self, n: u64) -> Result<()> {
         let mut buf = [0; 8];
         T::write_u64(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes a signed 64 bit integer to the underlying writer.
@@ -216,7 +212,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_i64<T: ByteOrder>(&mut self, n: i64) -> Result<()> {
         let mut buf = [0; 8];
         T::write_i64(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes an unsigned n-bytes integer to the underlying writer.
@@ -231,7 +227,7 @@ pub trait WriteBytesExt: io::Write {
     ) -> Result<()> {
         let mut buf = [0; 8];
         T::write_uint(&mut buf, n, nbytes);
-        write_all(self, &buf[0..nbytes])
+        self.write_all(&buf[0..nbytes])
     }
 
     /// Writes a signed n-bytes integer to the underlying writer.
@@ -246,7 +242,7 @@ pub trait WriteBytesExt: io::Write {
     ) -> Result<()> {
         let mut buf = [0; 8];
         T::write_int(&mut buf, n, nbytes);
-        write_all(self, &buf[0..nbytes])
+        self.write_all(&buf[0..nbytes])
     }
 
     /// Writes a IEEE754 single-precision (4 bytes) floating point number to
@@ -255,7 +251,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_f32<T: ByteOrder>(&mut self, n: f32) -> Result<()> {
         let mut buf = [0; 4];
         T::write_f32(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 
     /// Writes a IEEE754 double-precision (8 bytes) floating point number to
@@ -264,7 +260,7 @@ pub trait WriteBytesExt: io::Write {
     fn write_f64<T: ByteOrder>(&mut self, n: f64) -> Result<()> {
         let mut buf = [0; 8];
         T::write_f64(&mut buf, n);
-        write_all(self, &buf)
+        self.write_all(&buf)
     }
 }
 

--- a/src/new.rs
+++ b/src/new.rs
@@ -1,69 +1,6 @@
-use std::error;
-use std::fmt;
-use std::io;
-use std::result;
+use std::io::{self, Result};
 
 use ByteOrder;
-
-/// A short-hand for `result::Result<T, byteorder::Error>`.
-pub type Result<T> = result::Result<T, Error>;
-
-/// An error type for reading bytes.
-///
-/// This is a thin wrapper over the standard `io::Error` type. Namely, it
-/// adds one additional error case: an unexpected EOF.
-///
-/// Note that this error is also used for the `write` methods to keep things
-/// consistent.
-#[derive(Debug)]
-pub enum Error {
-    /// An unexpected EOF.
-    ///
-    /// This occurs when a call to the underlying reader returns `0` bytes,
-    /// but more bytes are required to decode a meaningful value.
-    UnexpectedEOF,
-    /// Any underlying IO error that occurs while reading bytes.
-    Io(io::Error),
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error { Error::Io(err) }
-}
-
-impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        match err {
-            Error::Io(err) => err,
-            Error::UnexpectedEOF => io::Error::new(io::ErrorKind::Other,
-                                                   "unexpected EOF")
-        }
-    }
-}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            Error::UnexpectedEOF => write!(f, "Unexpected end of file."),
-            Error::Io(ref err) => err.fmt(f),
-        }
-    }
-}
-
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::UnexpectedEOF => "Unexpected end of file.",
-            Error::Io(ref err) => error::Error::description(err),
-        }
-    }
-
-    fn cause(&self) -> Option<&error::Error> {
-        match *self {
-            Error::UnexpectedEOF => None,
-            Error::Io(ref err) => err.cause(),
-        }
-    }
-}
 
 /// Extends `Read` with methods for reading numbers. (For `std::io`.)
 ///
@@ -91,7 +28,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_u8(&mut self) -> Result<u8> {
         let mut buf = [0; 1];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(buf[0])
     }
 
@@ -102,7 +39,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_i8(&mut self) -> Result<i8> {
         let mut buf = [0; 1];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(buf[0] as i8)
     }
 
@@ -110,7 +47,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_u16<T: ByteOrder>(&mut self) -> Result<u16> {
         let mut buf = [0; 2];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_u16(&buf))
     }
 
@@ -118,7 +55,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_i16<T: ByteOrder>(&mut self) -> Result<i16> {
         let mut buf = [0; 2];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_i16(&buf))
     }
 
@@ -126,7 +63,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_u32<T: ByteOrder>(&mut self) -> Result<u32> {
         let mut buf = [0; 4];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_u32(&buf))
     }
 
@@ -134,7 +71,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_i32<T: ByteOrder>(&mut self) -> Result<i32> {
         let mut buf = [0; 4];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_i32(&buf))
     }
 
@@ -142,7 +79,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_u64<T: ByteOrder>(&mut self) -> Result<u64> {
         let mut buf = [0; 8];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_u64(&buf))
     }
 
@@ -150,7 +87,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_i64<T: ByteOrder>(&mut self) -> Result<i64> {
         let mut buf = [0; 8];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_i64(&buf))
     }
 
@@ -158,7 +95,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_uint<T: ByteOrder>(&mut self, nbytes: usize) -> Result<u64> {
         let mut buf = [0; 8];
-        try!(read_full(self, &mut buf[..nbytes]));
+        try!(self.read_exact(&mut buf[..nbytes]));
         Ok(T::read_uint(&buf[..nbytes], nbytes))
     }
 
@@ -166,7 +103,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_int<T: ByteOrder>(&mut self, nbytes: usize) -> Result<i64> {
         let mut buf = [0; 8];
-        try!(read_full(self, &mut buf[..nbytes]));
+        try!(self.read_exact(&mut buf[..nbytes]));
         Ok(T::read_int(&buf[..nbytes], nbytes))
     }
 
@@ -175,7 +112,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_f32<T: ByteOrder>(&mut self) -> Result<f32> {
         let mut buf = [0; 4];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_f32(&buf))
     }
 
@@ -184,7 +121,7 @@ pub trait ReadBytesExt: io::Read {
     #[inline]
     fn read_f64<T: ByteOrder>(&mut self) -> Result<f64> {
         let mut buf = [0; 8];
-        try!(read_full(self, &mut buf));
+        try!(self.read_exact(&mut buf));
         Ok(T::read_f64(&buf))
     }
 }
@@ -192,19 +129,6 @@ pub trait ReadBytesExt: io::Read {
 /// All types that implement `Read` get methods defined in `ReadBytesExt`
 /// for free.
 impl<R: io::Read + ?Sized> ReadBytesExt for R {}
-
-fn read_full<R: io::Read + ?Sized>(rdr: &mut R, buf: &mut [u8]) -> Result<()> {
-    let mut nread = 0usize;
-    while nread < buf.len() {
-        match rdr.read(&mut buf[nread..]) {
-            Ok(0) => return Err(Error::UnexpectedEOF),
-            Ok(n) => nread += n,
-            Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {},
-            Err(e) => return Err(From::from(e))
-        }
-    }
-    Ok(())
-}
 
 fn write_all<W: io::Write + ?Sized>(wtr: &mut W, buf: &[u8]) -> Result<()> {
     wtr.write_all(buf).map_err(From::from)


### PR DESCRIPTION
Now that 1.6 is released, all of this functionality is stable in the standard library.