### PR TITLE
Add a method to read the first bytes of a float (and assume the rest are 0)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,8 +387,7 @@ pub trait ByteOrder
     ///
     /// This is useful for formats which serialize floats as little-endian integers and elid any
     /// trailing zeros in the low bits to save space.
-    /// The return value of read_float is always defined; signaling NaN's are turned into quiet
-    /// NaN's.
+    /// The return value is always defined; signaling NaN's may be turned into quiet NaN's.
     ///
     /// # Panics
     ///
@@ -520,7 +519,7 @@ pub trait ByteOrder
 
     /// Reads a IEEE754 single-precision (4 bytes) floating point number.
     ///
-    /// The return value of is always defined; signaling NaN's are turned into quiet NaN's.
+    /// The return value is always defined; signaling NaN's may be turned into quiet NaN's.
     ///
     /// # Panics
     ///
@@ -550,7 +549,7 @@ pub trait ByteOrder
 
     /// Reads a IEEE754 double-precision (8 bytes) floating point number.
     ///
-    /// The return value of is always defined; signaling NaN's are turned into quiet NaN's.
+    /// The return value is always defined; signaling NaN's may be turned into quiet NaN's.
     ///
     /// # Panics
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -905,7 +905,7 @@ impl ByteOrder for BigEndian {
         let ptr_out = out.as_mut_ptr();
         unsafe {
             copy_nonoverlapping(buf.as_ptr(), ptr_out.offset((8 - nbytes) as isize), nbytes);
-            if (out[0] == 0x7F || out[0] == 0xFF) && out[1] & 0xF0 == 0xF0 {
+            if (out[0] == 0x7F || out[0] == 0xFF) && ((out[1] & 0x0F) | out[2] | out[3] | out[4] | out[5] | out[6] | out[7] != 0) {
                 out[1] |= 0x08;
             }
             transmute((*(ptr_out as *const u64)).to_be())
@@ -1008,11 +1008,12 @@ impl ByteOrder for LittleEndian {
 
     #[inline]
     fn read_float(buf: &[u8], nbytes: usize) -> f64 {
+        assert!(1 <= nbytes && nbytes <= 8 && nbytes <= buf.len());
         let mut out = [0; 8];
         let ptr_out = out.as_mut_ptr();
         unsafe {
             copy_nonoverlapping(buf.as_ptr(), ptr_out.offset((8 - nbytes) as isize), nbytes);
-            if (out[7] == 0x7F || out[7] == 0xFF) && out[6] & 0xF0 == 0xF0 {
+            if (out[7] == 0x7F || out[7] == 0xFF) && ((out[6] & 0x0F) | out[5] | out[4] | out[3] | out[2] | out[1] | out[0] != 0) {
                 out[6] |= 0x08;
             }
             transmute((*(ptr_out as *const u64)).to_le())

--- a/src/new.rs
+++ b/src/new.rs
@@ -421,6 +421,17 @@ pub trait ReadBytesExt: io::Read {
 
     /// Reads a IEEE754 double-precision (8 bytes) floating point number from
     /// the underlying reader (padding with zeros).
+    ///
+    /// # Examples
+    ///
+    /// Read a little-endian double-precision floating point number from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{LittleEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xF0, 0x3F]);
+    /// assert_eq!(1.0, rdr.read_float::<LittleEndian>(2).unwrap());
     #[inline]
     fn read_float<T: ByteOrder>(&mut self, nbytes: usize) -> Result<f64> {
         let mut buf = [0; 8];

--- a/src/new.rs
+++ b/src/new.rs
@@ -418,6 +418,15 @@ pub trait ReadBytesExt: io::Read {
         try!(self.read_exact(&mut buf));
         Ok(T::read_f64(&buf))
     }
+
+    /// Reads a IEEE754 double-precision (8 bytes) floating point number from
+    /// the underlying reader (padding with zeros).
+    #[inline]
+    fn read_float<T: ByteOrder>(&mut self, nbytes: usize) -> Result<f64> {
+        let mut buf = [0; 8];
+        try!(self.read_exact(&mut buf[..nbytes]));
+        Ok(T::read_float(&buf[..nbytes], nbytes))
+    }
 }
 
 /// All types that implement `Read` get methods defined in `ReadBytesExt`


### PR DESCRIPTION
I'm not sure if this is broadly useful enough to be worth adding to the library, but I've found myself using a similar function to this several times in a recent project so I thought I'd submit a PR in case you wanted it.

The idea is to read the first n bytes of an f64 as a uint and then assume that the rest of the bytes are 0. This is very useful if you're parsing lots of compressed floats in little-endian format where the low bits (which are often zero) can be dropped (eg. due to a form of run length encoding, or other compression that drops sequences of zeros).