### PR TITLE
Add examples to most methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_u32(&mut buf, 1_000_000);
+    /// assert_eq!(1_000_000, LittleEndian::read_u32(&buf));
+    /// ```
     fn read_u32(buf: &[u8]) -> u32;
 
     /// Reads an unsigned 64 bit integer from `buf`.
@@ -147,6 +159,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_u64(&mut buf, 1_000_000);
+    /// assert_eq!(1_000_000, LittleEndian::read_u64(&buf));
+    /// ```
     fn read_u64(buf: &[u8]) -> u64;
 
     /// Reads an unsigned n-bytes integer from `buf`.
@@ -155,6 +179,18 @@ pub trait ByteOrder
     ///
     /// Panics when `nbytes < 1` or `nbytes > 8` or
     /// `buf.len() < nbytes`
+    ///
+    /// # Examples
+    ///
+    /// Write and read an n-byte number in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 3];
+    /// LittleEndian::write_uint(&mut buf, 1_000_000, 3);
+    /// assert_eq!(1_000_000, LittleEndian::read_uint(&buf, 3));
+    /// ```
     fn read_uint(buf: &[u8], nbytes: usize) -> u64;
 
     /// Writes an unsigned 16 bit integer `n` to `buf`.
@@ -162,6 +198,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 2`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 2];
+    /// LittleEndian::write_u16(&mut buf, 1_000_000);
+    /// assert_eq!(1_000_000, LittleEndian::read_u16(&buf));
+    /// ```
     fn write_u16(buf: &mut [u8], n: u16);
 
     /// Writes an unsigned 32 bit integer `n` to `buf`.
@@ -169,6 +217,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_u32(&mut buf, 1_000_000);
+    /// assert_eq!(1_000_000, LittleEndian::read_u32(&buf));
+    /// ```
     fn write_u32(buf: &mut [u8], n: u32);
 
     /// Writes an unsigned 64 bit integer `n` to `buf`.
@@ -176,6 +236,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_u64(&mut buf, 1_000_000);
+    /// assert_eq!(1_000_000, LittleEndian::read_u64(&buf));
+    /// ```
     fn write_u64(buf: &mut [u8], n: u64);
 
     /// Writes an unsigned integer `n` to `buf` using only `nbytes`.
@@ -184,6 +256,18 @@ pub trait ByteOrder
     ///
     /// If `n` is not representable in `nbytes`, or if `nbytes` is `> 8`, then
     /// this method panics.
+    ///
+    /// # Examples
+    ///
+    /// Write and read an n-byte number in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 3];
+    /// LittleEndian::write_uint(&mut buf, 1_000_000, 3);
+    /// assert_eq!(1_000_000, LittleEndian::read_uint(&buf, 3));
+    /// ```
     fn write_uint(buf: &mut [u8], n: u64, nbytes: usize);
 
     /// Reads a signed 16 bit integer from `buf`.
@@ -191,6 +275,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 2`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 2];
+    /// LittleEndian::write_i16(&mut buf, -1_000);
+    /// assert_eq!(-1_000, LittleEndian::read_i16(&buf));
+    /// ```
     #[inline]
     fn read_i16(buf: &[u8]) -> i16 {
         Self::read_u16(buf) as i16
@@ -201,6 +297,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_i32(&mut buf, -1_000_000);
+    /// assert_eq!(-1_000_000, LittleEndian::read_i32(&buf));
+    /// ```
     #[inline]
     fn read_i32(buf: &[u8]) -> i32 {
         Self::read_u32(buf) as i32
@@ -211,6 +319,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_i64(&mut buf, -1_000_000_000);
+    /// assert_eq!(-1_000_000_000, LittleEndian::read_i64(&buf));
+    /// ```
     #[inline]
     fn read_i64(buf: &[u8]) -> i64 {
         Self::read_u64(buf) as i64
@@ -222,6 +342,18 @@ pub trait ByteOrder
     ///
     /// Panics when `nbytes < 1` or `nbytes > 8` or
     /// `buf.len() < nbytes`
+    ///
+    /// # Examples
+    ///
+    /// Write and read n-length signed numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 3];
+    /// LittleEndian::write_int(&mut buf, -1_000, 3);
+    /// assert_eq!(-1_000, LittleEndian::read_int(&buf, 3));
+    /// ```
     #[inline]
     fn read_int(buf: &[u8], nbytes: usize) -> i64 {
         extend_sign(Self::read_uint(buf, nbytes), nbytes)
@@ -232,6 +364,19 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let e = 2.71828;
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_f32(&mut buf, e);
+    /// assert_eq!(e, LittleEndian::read_f32(&buf));
+    /// ```
     #[inline]
     fn read_f32(buf: &[u8]) -> f32 {
         unsafe { transmute(Self::read_u32(buf)) }
@@ -242,6 +387,19 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let phi = 1.6180339887;
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_f64(&mut buf, phi);
+    /// assert_eq!(phi, LittleEndian::read_f64(&buf));
+    /// ```
     #[inline]
     fn read_f64(buf: &[u8]) -> f64 {
         unsafe { transmute(Self::read_u64(buf)) }
@@ -252,6 +410,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 2`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 2];
+    /// LittleEndian::write_i16(&mut buf, -1_000);
+    /// assert_eq!(-1_000, LittleEndian::read_i16(&buf));
+    /// ```
     #[inline]
     fn write_i16(buf: &mut [u8], n: i16) {
         Self::write_u16(buf, n as u16)
@@ -262,6 +432,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_i32(&mut buf, -1_000_000);
+    /// assert_eq!(-1_000_000, LittleEndian::read_i32(&buf));
+    /// ```
     #[inline]
     fn write_i32(buf: &mut [u8], n: i32) {
         Self::write_u32(buf, n as u32)
@@ -272,6 +454,18 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_i64(&mut buf, -1_000_000_000);
+    /// assert_eq!(-1_000_000_000, LittleEndian::read_i64(&buf));
+    /// ```
     #[inline]
     fn write_i64(buf: &mut [u8], n: i64) {
         Self::write_u64(buf, n as u64)
@@ -283,6 +477,18 @@ pub trait ByteOrder
     ///
     /// If `n` is not representable in `nbytes`, or if `nbytes` is `> 8`, then
     /// this method panics.
+    ///
+    /// # Examples
+    ///
+    /// Write and read an n-byte number in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 3];
+    /// LittleEndian::write_int(&mut buf, -1_000, 3);
+    /// assert_eq!(-1_000, LittleEndian::read_int(&buf, 3));
+    /// ```
     #[inline]
     fn write_int(buf: &mut [u8], n: i64, nbytes: usize) {
         Self::write_uint(buf, unextend_sign(n, nbytes), nbytes)
@@ -293,6 +499,19 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 4`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let e = 2.71828;
+    /// let mut buf = [0; 4];
+    /// LittleEndian::write_f32(&mut buf, e);
+    /// assert_eq!(e, LittleEndian::read_f32(&buf));
+    /// ```
     #[inline]
     fn write_f32(buf: &mut [u8], n: f32) {
         Self::write_u32(buf, unsafe { transmute(n) })
@@ -303,6 +522,19 @@ pub trait ByteOrder
     /// # Panics
     ///
     /// Panics when `buf.len() < 8`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let phi = 1.6180339887;
+    /// let mut buf = [0; 8];
+    /// LittleEndian::write_f64(&mut buf, phi);
+    /// assert_eq!(phi, LittleEndian::read_f64(&buf));
+    /// ```
     #[inline]
     fn write_f64(buf: &mut [u8], n: f64) {
         Self::write_u64(buf, unsafe { transmute(n) })
@@ -313,6 +545,18 @@ pub trait ByteOrder
 ///
 /// Note that this type has no value constructor. It is used purely at the
 /// type level.
+///
+/// # Examples
+///
+/// Write and read `u32` numbers in big endian order:
+///
+/// ```rust
+/// use byteorder::{ByteOrder, BigEndian};
+///
+/// let mut buf = [0; 4];
+/// BigEndian::write_u32(&mut buf, 1_000_000);
+/// assert_eq!(1_000_000, BigEndian::read_u32(&buf));
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum BigEndian {}
 
@@ -326,6 +570,18 @@ impl Default for BigEndian {
 ///
 /// Note that this type has no value constructor. It is used purely at the
 /// type level.
+///
+/// # Examples
+///
+/// Write and read `u32` numbers in little endian order:
+///
+/// ```rust
+/// use byteorder::{ByteOrder, LittleEndian};
+///
+/// let mut buf = [0; 4];
+/// LittleEndian::write_u32(&mut buf, 1_000_000);
+/// assert_eq!(1_000_000, LittleEndian::read_u32(&buf));
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum LittleEndian {}
 
@@ -345,6 +601,18 @@ impl Default for LittleEndian {
 ///
 /// Note that this type has no value constructor. It is used purely at the
 /// type level.
+///
+/// # Examples
+///
+/// Write and read `i16` numbers in big endian order:
+///
+/// ```rust
+/// use byteorder::{ByteOrder, NetworkEndian, BigEndian};
+///
+/// let mut buf = [0; 2];
+/// BigEndian::write_i16(&mut buf, -50_000);
+/// assert_eq!(-50_000, NetworkEndian::read_i16(&buf));
+/// ```
 pub type NetworkEndian = BigEndian;
 
 /// Defines system native-endian serialization.

--- a/src/new.rs
+++ b/src/new.rs
@@ -31,6 +31,19 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5]);
+    /// assert_eq!(2, rdr.read_u8().unwrap());
+    /// assert_eq!(5, rdr.read_u8().unwrap());
+    /// ```
     #[inline]
     fn read_u8(&mut self) -> Result<u8> {
         let mut buf = [0; 1];
@@ -48,6 +61,19 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x02, 0xfb]);
+    /// assert_eq!(2, rdr.read_i8().unwrap());
+    /// assert_eq!(-5, rdr.read_i8().unwrap());
+    /// ```
     #[inline]
     fn read_i8(&mut self) -> Result<i8> {
         let mut buf = [0; 1];
@@ -62,6 +88,19 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5, 3, 0]);
+    /// assert_eq!(517, rdr.read_u16::<BigEndian>().unwrap());
+    /// assert_eq!(768, rdr.read_u16::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_u16<T: ByteOrder>(&mut self) -> Result<u16> {
         let mut buf = [0; 2];
@@ -76,6 +115,19 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 16 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0xc1, 0xff, 0x7c]);
+    /// assert_eq!(193, rdr.read_i16::<BigEndian>().unwrap());
+    /// assert_eq!(-132, rdr.read_i16::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_i16<T: ByteOrder>(&mut self) -> Result<i16> {
         let mut buf = [0; 2];
@@ -90,6 +142,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read unsigned 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0x00, 0x01, 0x0b]);
+    /// assert_eq!(267, rdr.read_u32::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_u32<T: ByteOrder>(&mut self) -> Result<u32> {
         let mut buf = [0; 4];
@@ -104,6 +168,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read signed 32 bit big-endian integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xff, 0xff, 0x7a, 0x33]);
+    /// assert_eq!(-34253, rdr.read_i32::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_i32<T: ByteOrder>(&mut self) -> Result<i32> {
         let mut buf = [0; 4];
@@ -118,6 +194,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned 64 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x00, 0x03, 0x43, 0x95, 0x4d, 0x60, 0x86, 0x83]);
+    /// assert_eq!(918733457491587, rdr.read_u64::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_u64<T: ByteOrder>(&mut self) -> Result<u64> {
         let mut buf = [0; 8];
@@ -132,6 +220,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a signed 64 bit big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x80, 0, 0, 0, 0, 0, 0, 0]);
+    /// assert_eq!(i64::min_value(), rdr.read_i64::<BigEndian>().unwrap());
+    /// ```
     #[inline]
     fn read_i64<T: ByteOrder>(&mut self) -> Result<i64> {
         let mut buf = [0; 8];
@@ -146,6 +246,17 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned n-byte big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0x80, 0x74, 0xfa]);
+    /// assert_eq!(8418554, rdr.read_uint::<BigEndian>(3).unwrap());
     #[inline]
     fn read_uint<T: ByteOrder>(&mut self, nbytes: usize) -> Result<u64> {
         let mut buf = [0; 8];
@@ -160,6 +271,17 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read an unsigned n-byte big-endian integer from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![0xc1, 0xff, 0x7c]);
+    /// assert_eq!(-4063364, rdr.read_int::<BigEndian>(3).unwrap());
     #[inline]
     fn read_int<T: ByteOrder>(&mut self, nbytes: usize) -> Result<i64> {
         let mut buf = [0; 8];
@@ -175,6 +297,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a big-endian single-precision floating point number from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    /// use std::f32::consts;
+    ///
+    /// let mut rdr = Cursor::new(vec![0x40, 0x49, 0x0f, 0xdb]);
+    /// assert_eq!(consts::PI, rdr.read_f32::<BigEndian>().unwrap());
     #[inline]
     fn read_f32<T: ByteOrder>(&mut self) -> Result<f32> {
         let mut buf = [0; 4];
@@ -191,6 +325,18 @@ pub trait ReadBytesExt: io::Read {
     /// This method returns the same errors as [`Read::read_exact`].
     ///
     /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a big-endian double-precision floating point number from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    /// use std::f64::consts;
+    ///
+    /// let mut rdr = Cursor::new(vec![0x40, 0x09, 0x21, 0xfb, 0x54, 0x44, 0x2d, 0x18]);
+    /// assert_eq!(consts::PI, rdr.read_f64::<BigEndian>().unwrap());
     fn read_f64<T: ByteOrder>(&mut self) -> Result<f64> {
         let mut buf = [0; 8];
         try!(self.read_exact(&mut buf));


### PR DESCRIPTION
I think there might be a handful of extra things that I missed, but this copies the basic examples from the trait docs into the actual methods (updating for bit width / signedness, of course). Most examples use little endian ordering except the ones on the `BigEndian` type itself.

Examples are identical for same sign/width read/write methods so there's some duplication that's not strictly necessary, but it will look nice in the docs and means you don't have to go hunting for an example.

Updates #75
Updates #76 