### PR TITLE
Fix some typos in the docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u16` numbers in little endian order:
+    /// Write and read `i16` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};
@@ -412,7 +412,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u32` numbers in little endian order:
+    /// Write and read `i32` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};
@@ -434,7 +434,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u64` numbers in little endian order:
+    /// Write and read `i64` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};
@@ -548,7 +548,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u16` numbers in little endian order:
+    /// Write and read `i16` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};
@@ -570,7 +570,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u32` numbers in little endian order:
+    /// Write and read `i32` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};
@@ -592,7 +592,7 @@ pub trait ByteOrder
     ///
     /// # Examples
     ///
-    /// Write and read `u64` numbers in little endian order:
+    /// Write and read `i64` numbers in little endian order:
     ///
     /// ```rust
     /// use byteorder::{ByteOrder, LittleEndian};


### PR DESCRIPTION
Unsigned integer types were given for the signed functions of the ByteOrder trait