### PR TITLE
Add OppositeNativeEndian alias

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -787,6 +787,22 @@ pub type NativeEndian = LittleEndian;
 #[cfg(target_endian = "big")]
 pub type NativeEndian = BigEndian;
 
+/// Defines the serialization that is opposite to system native-endian.
+/// This is `BigEndian` in a Little Endian system and `LittleEndian` in a Big Endian system.
+///
+/// Note that this type has no value constructor. It is used purely at the
+/// type level.
+#[cfg(target_endian = "little")]
+pub type OppositeNativeEndian = BigEndian;
+
+/// Defines the serialization that is opposite to system native-endian.
+/// This is `BigEndian` in a Little Endian system and `LittleEndian` in a Big Endian system.
+///
+/// Note that this type has no value constructor. It is used purely at the
+/// type level.
+#[cfg(target_endian = "big")]
+pub type OppositeNativeEndian = LittleEndian;
+
 macro_rules! read_num_bytes {
     ($ty:ty, $size:expr, $src:expr, $which:ident) => ({
         assert!($size == ::core::mem::size_of::<$ty>());
@@ -1066,7 +1082,7 @@ mod test {
         ($name:ident, $ty_int:ty, $max:expr,
          $bytes:expr, $read:ident, $write:ident) => (
             mod $name {
-                use {BigEndian, ByteOrder, NativeEndian, LittleEndian};
+                use {BigEndian, ByteOrder, NativeEndian, OppositeNativeEndian, LittleEndian};
                 #[allow(unused_imports)] use super::{ qc_sized, Wi128 };
 
                 #[test]
@@ -1095,6 +1111,16 @@ mod test {
                         let mut buf = [0; 16];
                         NativeEndian::$write(&mut buf, n.clone(), $bytes);
                         n == NativeEndian::$read(&mut buf[..$bytes], $bytes)
+                    }
+                    qc_sized(prop as fn($ty_int) -> bool, $max);
+                }
+                
+                #[test]
+                fn opposite_native_endian() {
+                    fn prop(n: $ty_int) -> bool {
+                        let mut buf = [0; 16];
+                        OppositeNativeEndian::$write(&mut buf, n.clone(), $bytes);
+                        n == OppositeNativeEndian::$read(&mut buf[..$bytes], $bytes)
                     }
                     qc_sized(prop as fn($ty_int) -> bool, $max);
                 }


### PR DESCRIPTION
This PR is merely a proposal for an addition that is indeed awkard: an alias for `LittleEndian` in a big endian system and `BigEndian` in a little endian system. However, I stumbled upon a use case where it is actually useful, and I thought of at least sharing it.

The [NIfTI-1](https://nifti.nimh.nih.gov/nifti-1) data format does not specify a byte order for the file, so its contents could be in either endianness. In order to detect the file's byte order, the specification of the format itself advises implementations to check the value of a very specific field (`dim[0]`), and swap all fields if it's not between 1 and 7. An efficient solution would begin reading the header in system-native endian up to this value, and choose whether to continue reading the same way after `dim[0]` or swap everything before that and continue with the opposite byte order. It becomes an elegant solution when separated in two functions.

Of course, given the nature of this alias and its trivial implementation, feel free to close this PR if you think it doesn't quite fit in.