### PR TITLE
Slice methods addition

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1338,7 +1338,7 @@ macro_rules! write_slice {
                 $src.as_ptr() as *const u8,
                 $dst.as_mut_ptr(),
                 $dst.len());
-            let tmp: &mut [$ty] = transmute(&mut *$dst);
+            let tmp: &mut [$ty] = transmute($dst);
             for v in tmp[..$src.len()].iter_mut() {
                 *v = v.$which();
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1045,20 +1045,20 @@ impl ByteOrder for BigEndian {
         read_slice!(buf, dst, 16, to_be);
     }
 
-    /// Read u16 slice
+    #[inline]
     fn write_u16v(buf: &mut [u8], src: &[u16]) {
         write_slice!(src, buf, 2, to_be);
     }
-    /// Read u32 slice
+    #[inline]
     fn write_u32v(buf: &mut [u8], src: &[u32]) {
         write_slice!(src, buf, 4, to_be);
     }
-    /// Read u64 slice
+    #[inline]
     fn write_u64v(buf: &mut [u8], src: &[u64]) {
         write_slice!(src, buf, 8, to_be);
     }
-    /// Read u128 slice
     #[cfg(feature = "i128")]
+    #[inline]
     fn write_u128v(buf: &mut [u8], src: &[u128]) {
         write_slice!(src, buf, 16, to_be);
     }
@@ -1172,20 +1172,20 @@ impl ByteOrder for LittleEndian {
         read_slice!(buf, dst, 16, to_le);
     }
 
-    /// Read u16 slice
+    #[inline]
     fn write_u16v(buf: &mut [u8], src: &[u16]) {
         write_slice!(src, buf, 2, to_le);
     }
-    /// Read u32 slice
+    #[inline]
     fn write_u32v(buf: &mut [u8], src: &[u32]) {
         write_slice!(src, buf, 4, to_le);
     }
-    /// Read u64 slice
+    #[inline]
     fn write_u64v(buf: &mut [u8], src: &[u64]) {
         write_slice!(src, buf, 8, to_le);
     }
-    /// Read u128 slice
     #[cfg(feature = "i128")]
+    #[inline]
     fn write_u128v(buf: &mut [u8], src: &[u128]) {
         write_slice!(src, buf, 16, to_le);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,47 +288,253 @@ pub trait ByteOrder
     #[cfg(feature = "i128")]
     fn read_uint128(buf: &[u8], nbytes: usize) -> u128;
 
-
-
-
-    /// Read u16 slice
+    /// Reads unsigned 16 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 2*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u16v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u16v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn read_u16v(dst: &mut [u16], buf: &[u8]);
-    /// Read u32 slice
+
+    /// Reads unsigned 32 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u32v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn read_u32v(dst: &mut [u32], buf: &[u8]);
-    /// Read u64 slice
+
+    /// Reads unsigned 64 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u64v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn read_u64v(dst: &mut [u64], buf: &[u8]);
-    /// Read u128 slice
+
+    /// Reads unsigned 128 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 16*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u128` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 64];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u128v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u128v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[cfg(feature = "i128")]
-    fn read_u128v(dst: &mut [i128], buf: &[u8]);
+    fn read_u128v(dst: &mut [u128], buf: &[u8]);
 
-
-    /// Read i16 slice
+    /// Reads signed 16 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 2*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i16v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i16v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[inline]
     fn read_i16v(dst: &mut [i16], buf: &[u8]) {
         Self::read_u16v(unsafe{ transmute(dst) }, buf);
     }
-    /// Read i32 slice
+
+    /// Reads signed 32 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i32v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[inline]
     fn read_i32v(dst: &mut [i32], buf: &[u8]) {
         Self::read_u32v(unsafe{ transmute(dst) }, buf);
     }
-    /// Read i64 slice
+
+    /// Reads signed 64 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i64v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[inline]
     fn read_i64v(dst: &mut [i64], buf: &[u8]) {
         Self::read_u64v(unsafe{ transmute(dst) }, buf);
     }
-    /// Read i128 slice
+
+    /// Reads signed 128 bit integers from `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 16*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i128` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 64];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i128v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i128v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[cfg(feature = "i128")]
     #[inline]
     fn read_i128v(dst: &mut [i128], buf: &[u8]) {
         Self::read_u128v(unsafe{ transmute(dst) }, buf);
     }
-    /// Read f32 slice
+
+    /// Reads IEEE754 single-precision (4 bytes) floating point numbers from
+    /// `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_f32v(&mut buf, &val);
+    /// let mut val2 = [0.0; 4];
+    /// LittleEndian::read_f32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[inline]
     fn read_f32v(dst: &mut [f32], buf: &[u8]) {
         Self::read_u32v(unsafe{ transmute(dst) }, buf);
     }
-    /// Read f64 slice
+
+    /// Reads IEEE754 double-precision (8 bytes) floating point numbers from
+    /// `buf` to `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_f64v(&mut buf, &val);
+    /// let mut val2 = [0.0; 4];
+    /// LittleEndian::read_f64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[inline]
     fn read_f64v(dst: &mut [f64], buf: &[u8]) {
         Self::read_u64v(unsafe{ transmute(dst) }, buf);
@@ -921,7 +1127,7 @@ macro_rules! write_slice {
             copy_nonoverlapping(
                 $src.as_ptr() as *const u8,
                 $dst.as_mut_ptr(),
-                $src.len());
+                $dst.len());
         }
         for v in $dst.iter_mut() {
             *v = v.$which();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1330,16 +1330,18 @@ macro_rules! read_slice {
 }
 
 macro_rules! write_slice {
-    ($src:expr, $dst:expr, $size:expr, $which:ident) => ({
+    ($src:expr, $dst:expr, $ty:ty, $size:expr, $which:ident) => ({
+        assert!($size == ::core::mem::size_of::<$ty>());
         assert_eq!($dst.len(), $size*$src.len());
         unsafe {
             copy_nonoverlapping(
                 $src.as_ptr() as *const u8,
                 $dst.as_mut_ptr(),
                 $dst.len());
-        }
-        for v in $dst.iter_mut() {
-            *v = v.$which();
+            let tmp: &mut [$ty] = transmute(&mut *$dst);
+            for v in tmp[..$src.len()].iter_mut() {
+                *v = v.$which();
+            }
         }
     });
 }
@@ -1462,20 +1464,20 @@ impl ByteOrder for BigEndian {
 
     #[inline]
     fn write_u16v(buf: &mut [u8], src: &[u16]) {
-        write_slice!(src, buf, 2, to_be);
+        write_slice!(src, buf, u16, 2, to_be);
     }
     #[inline]
     fn write_u32v(buf: &mut [u8], src: &[u32]) {
-        write_slice!(src, buf, 4, to_be);
+        write_slice!(src, buf, u32, 4, to_be);
     }
     #[inline]
     fn write_u64v(buf: &mut [u8], src: &[u64]) {
-        write_slice!(src, buf, 8, to_be);
+        write_slice!(src, buf, u64, 8, to_be);
     }
     #[cfg(feature = "i128")]
     #[inline]
     fn write_u128v(buf: &mut [u8], src: &[u128]) {
-        write_slice!(src, buf, 16, to_be);
+        write_slice!(src, buf, u128, 16, to_be);
     }
 }
 
@@ -1589,20 +1591,20 @@ impl ByteOrder for LittleEndian {
 
     #[inline]
     fn write_u16v(buf: &mut [u8], src: &[u16]) {
-        write_slice!(src, buf, 2, to_le);
+        write_slice!(src, buf, u16, 2, to_le);
     }
     #[inline]
     fn write_u32v(buf: &mut [u8], src: &[u32]) {
-        write_slice!(src, buf, 4, to_le);
+        write_slice!(src, buf, u32, 4, to_le);
     }
     #[inline]
     fn write_u64v(buf: &mut [u8], src: &[u64]) {
-        write_slice!(src, buf, 8, to_le);
+        write_slice!(src, buf, u64, 8, to_le);
     }
     #[cfg(feature = "i128")]
     #[inline]
     fn write_u128v(buf: &mut [u8], src: &[u128]) {
-        write_slice!(src, buf, 16, to_le);
+        write_slice!(src, buf, u128, 16, to_le);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -952,40 +952,249 @@ pub trait ByteOrder
         Self::write_u64(buf, unsafe { transmute(n) })
     }
 
-    /// Write u16 slice
+    /// Writes unsigned 16 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 2*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u16v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u16v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_u16v(buf: &mut [u8], src: &[u16]);
-    /// Write u32 slice
+
+    /// Writes unsigned 32 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u32v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_u32v(buf: &mut [u8], src: &[u32]);
-    /// Write u64 slice
+
+    /// Writes unsigned 64 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u64v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_u64v(buf: &mut [u8], src: &[u64]);
-    /// Write u128 slice
+
+    /// Writes unsigned 128 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 16*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `u128` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 64];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_u128v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_u128v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[cfg(feature = "i128")]
     fn write_u128v(buf: &mut [u8], src: &[u128]);
 
 
-    /// Write i16 slice
+    /// Writes signed 16 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 2*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i16` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 8];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i16v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i16v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_i16v(buf: &mut [u8], src: &[i16]) {
         Self::write_u16v(buf, unsafe{ transmute(src) });
     }
-    /// Write i32 slice
+
+    /// Writes signed 32 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i32v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_i32v(buf: &mut [u8], src: &[i32]) {
         Self::write_u32v(buf, unsafe{ transmute(src) });
     }
-    /// Write i64 slice
+
+    /// Writes signed 64 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i64v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_i64v(buf: &mut [u8], src: &[i64]) {
         Self::write_u64v(buf, unsafe{ transmute(src) });
     }
-    /// Write i128 slice
+
+    /// Writes signed 128 bit integers from `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 16*src.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `i128` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 64];
+    /// let val = [1, 2, 0xf00f, 0xffee];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_i128v(&mut buf, &val);
+    /// let mut val2 = [0; 4];
+    /// LittleEndian::read_i128v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     #[cfg(feature = "i128")]
     fn write_i128v(buf: &mut [u8], src: &[i128]) {
         Self::write_u128v(buf, unsafe{ transmute(src) });
     }
 
-    /// Write f32 slice
+    /// Writes IEEE754 single-precision (4 bytes) floating point numbers from
+    /// `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 4*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 16];
+    /// let val = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_f32v(&mut buf, &val);
+    /// let mut val2 = [0.0; 4];
+    /// LittleEndian::read_f32v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_f32v(buf: &mut [u8], src: &[f32]) {
         Self::write_u32v(buf, unsafe{ transmute(src) });
     }
-    /// Write f64 slice
+
+    /// Writes IEEE754 double-precision (8 bytes) floating point numbers from
+    /// `src` to `buf`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `buf.len() != 8*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut buf = [0; 32];
+    /// let val = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// print!("{:?}", val);
+    /// LittleEndian::write_f64v(&mut buf, &val);
+    /// let mut val2 = [0.0; 4];
+    /// LittleEndian::read_f64v(&mut val2, &buf);
+    /// assert_eq!(val, val2);
+    /// ```
     fn write_f64v(buf: &mut [u8], src: &[f64]) {
         Self::write_u64v(buf, unsafe{ transmute(src) });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,15 +288,53 @@ pub trait ByteOrder
     #[cfg(feature = "i128")]
     fn read_uint128(buf: &[u8], nbytes: usize) -> u128;
 
+
+
+
     /// Read u16 slice
-    fn read_u16v(dst: &mut [u32], buf: &[u8]);
+    fn read_u16v(dst: &mut [u16], buf: &[u8]);
     /// Read u32 slice
     fn read_u32v(dst: &mut [u32], buf: &[u8]);
     /// Read u64 slice
     fn read_u64v(dst: &mut [u64], buf: &[u8]);
     /// Read u128 slice
     #[cfg(feature = "i128")]
-    fn read_u128v(dst: &mut [u128], buf: &[u8]);
+    fn read_u128v(dst: &mut [i128], buf: &[u8]);
+
+
+    /// Read i16 slice
+    #[inline]
+    fn read_i16v(dst: &mut [i16], buf: &[u8]) {
+        Self::read_u16v(unsafe{ transmute(dst) }, buf);
+    }
+    /// Read i32 slice
+    #[inline]
+    fn read_i32v(dst: &mut [i32], buf: &[u8]) {
+        Self::read_u32v(unsafe{ transmute(dst) }, buf);
+    }
+    /// Read i64 slice
+    #[inline]
+    fn read_i64v(dst: &mut [i64], buf: &[u8]) {
+        Self::read_u64v(unsafe{ transmute(dst) }, buf);
+    }
+    /// Read i128 slice
+    #[cfg(feature = "i128")]
+    #[inline]
+    fn read_i128v(dst: &mut [i128], buf: &[u8]) {
+        Self::read_u128v(unsafe{ transmute(dst) }, buf);
+    }
+    /// Read f32 slice
+    #[inline]
+    fn read_f32v(dst: &mut [f32], buf: &[u8]) {
+        Self::read_u32v(unsafe{ transmute(dst) }, buf);
+    }
+    /// Read f64 slice
+    #[inline]
+    fn read_f64v(dst: &mut [f64], buf: &[u8]) {
+        Self::read_u64v(unsafe{ transmute(dst) }, buf);
+    }
+
+
 
     /// Writes an unsigned 16 bit integer `n` to `buf`.
     ///
@@ -717,6 +755,34 @@ pub trait ByteOrder
     /// Write u128 slice
     #[cfg(feature = "i128")]
     fn write_u128v(buf: &mut [u8], src: &[u128]);
+
+
+    /// Write i16 slice
+    fn write_i16v(buf: &mut [u8], src: &[i16]) {
+        Self::write_u16v(buf, unsafe{ transmute(src) });
+    }
+    /// Write i32 slice
+    fn write_i32v(buf: &mut [u8], src: &[i32]) {
+        Self::write_u32v(buf, unsafe{ transmute(src) });
+    }
+    /// Write i64 slice
+    fn write_i64v(buf: &mut [u8], src: &[i64]) {
+        Self::write_u64v(buf, unsafe{ transmute(src) });
+    }
+    /// Write i128 slice
+    #[cfg(feature = "i128")]
+    fn write_i128v(buf: &mut [u8], src: &[i128]) {
+        Self::write_u128v(buf, unsafe{ transmute(src) });
+    }
+
+    /// Write f32 slice
+    fn write_f32v(buf: &mut [u8], src: &[f32]) {
+        Self::write_u32v(buf, unsafe{ transmute(src) });
+    }
+    /// Write f64 slice
+    fn write_f64v(buf: &mut [u8], src: &[f64]) {
+        Self::write_u64v(buf, unsafe{ transmute(src) });
+    }
 }
 
 /// Defines big-endian serialization.
@@ -959,7 +1025,7 @@ impl ByteOrder for BigEndian {
     }
 
     #[inline]
-    fn read_u16v(dst: &mut [u32], buf: &[u8]) {
+    fn read_u16v(dst: &mut [u16], buf: &[u8]) {
         read_slice!(buf, dst, 2, to_be);
     }
 
@@ -1086,7 +1152,7 @@ impl ByteOrder for LittleEndian {
     }
 
     #[inline]
-    fn read_u16v(dst: &mut [u32], buf: &[u8]) {
+    fn read_u16v(dst: &mut [u16], buf: &[u8]) {
         read_slice!(buf, dst, 2, to_le);
     }
 


### PR DESCRIPTION
Per #63.
If this approach is alright with you, I will add signed and float methods, docs and tests.

I think this loop should be optimized out if `$which` same as native endianness (i.e. `to_le` on little endiann machine), but it's better to check:
```Rust
for v in $dst.iter_mut() {
    *v = v.$which();
}
```

Also this part in `write_slice!` is a bit dirty and probably can be written better:
```Rust
let tmp: &mut [$ty] = transmute($dst);
for v in tmp[..$src.len()].iter_mut() {
    *v = v.$which();
}
```