### PR TITLE
Cleanup CI badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ i128 = []
 opt-level = 3
 
 [badges]
-travis-ci = { repository = "https://github.com/BurntSushi/byteorder", branch = "master" }
+travis-ci = { repository = "BurntSushi/byteorder" }


### PR DESCRIPTION
The `repository` key only takes the username and repository name, not a full URL (the default `service` is GitHub). See http://doc.crates.io/manifest.html

The `branch` key defaults to `master` so I removed it for simplicity.