### PR TITLE
Use SVG for Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This crate provides convenience methods for encoding and decoding numbers in
 either big-endian or little-endian order.
 
-[![Build status](https://api.travis-ci.org/BurntSushi/byteorder.png)](https://travis-ci.org/BurntSushi/byteorder)
+[![Build status](https://api.travis-ci.org/BurntSushi/byteorder.svg)](https://travis-ci.org/BurntSushi/byteorder)
 [![](http://meritbadge.herokuapp.com/byteorder)](https://crates.io/crates/byteorder)
 
 Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).


### PR DESCRIPTION
PNG looks pixelated on Apple's retina screens.