### PR TITLE
Use depcrated tag instead of pure documentation

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -860,6 +860,7 @@ pub trait ReadBytesExt: io::Read {
     /// assert_eq!([f32::consts::PI, 1.0], dst);
     /// ```
     #[inline]
+    #[deprecated(since="1.2.0", note="please use `read_f32_into` instead")]
     fn read_f32_into_unchecked<T: ByteOrder>(
         &mut self,
         dst: &mut [f32],
@@ -953,6 +954,7 @@ pub trait ReadBytesExt: io::Read {
     /// assert_eq!([f64::consts::PI, 1.0], dst);
     /// ```
     #[inline]
+    #[deprecated(since="1.2.0", note="please use `read_f64_into` instead")]
     fn read_f64_into_unchecked<T: ByteOrder>(
         &mut self,
         dst: &mut [f64],


### PR DESCRIPTION
Since nearly 2 years, there is a depcrated attribute, which can be used 
https://github.com/rust-lang/rfcs/blob/master/text/1270-deprecation.md