### PR TITLE
rollup + fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,39 @@
 language: rust
-rust:
-  - 1.12.0
-  - stable
-  - beta
-  - nightly
+
+matrix:
+  include:
+    - rust: 1.12.0
+    - rust: stable
+    - rust: beta
+    - rust: nightly
+    - env: CROSS_TARGET=mips64-unknown-linux-gnuabi64
+      rust: stable
+      services: docker
+      sudo: required
+
+before_script:
+  - if [ ! -z "$CROSS_TARGET" ]; then
+      rustup target add $CROSS_TARGET;
+      cargo install cross --force;
+      export CARGO_CMD="cross";
+      export TARGET_PARAM="--target $CROSS_TARGET";
+    else
+      export CARGO_CMD=cargo;
+      export TARGET_PARAM="";
+    fi
+
 script:
-  - cargo build --verbose
-  - cargo doc
-  - cargo test --verbose
-  - cargo test --verbose --no-default-features --lib
+  - $CARGO_CMD build $TARGET_PARAM --verbose 
+  - $CARGO_CMD doc $TARGET_PARAM
+  - $CARGO_CMD test $TARGET_PARAM --verbose
+  - $CARGO_CMD test $TARGET_PARAM --verbose --no-default-features --lib
   - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      cargo test --verbose --features i128;
-      cargo test --verbose --no-default-features --features i128 --lib;
-      cargo bench --verbose --no-run;
-      cargo bench --verbose --no-run --no-default-features;
-      cargo bench --verbose --no-run --features i128;
-      cargo bench --verbose --no-run --no-default-features --features i128;
+      $CARGO_CMD test $TARGET_PARAM --verbose --features i128;
+      $CARGO_CMD test $TARGET_PARAM --verbose --no-default-features --features i128 --lib;
+      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run;
+      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --no-default-features;
+      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --features i128;
+      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --no-default-features --features i128;
     fi
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: rust
-
 matrix:
   include:
     - rust: 1.12.0
@@ -10,31 +9,7 @@ matrix:
       rust: stable
       services: docker
       sudo: required
-
-before_script:
-  - if [ ! -z "$CROSS_TARGET" ]; then
-      rustup target add $CROSS_TARGET;
-      cargo install cross --force;
-      export CARGO_CMD="cross";
-      export TARGET_PARAM="--target $CROSS_TARGET";
-    else
-      export CARGO_CMD=cargo;
-      export TARGET_PARAM="";
-    fi
-
-script:
-  - $CARGO_CMD build $TARGET_PARAM --verbose 
-  - $CARGO_CMD doc $TARGET_PARAM
-  - $CARGO_CMD test $TARGET_PARAM --verbose
-  - $CARGO_CMD test $TARGET_PARAM --verbose --no-default-features --lib
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      $CARGO_CMD test $TARGET_PARAM --verbose --features i128;
-      $CARGO_CMD test $TARGET_PARAM --verbose --no-default-features --features i128 --lib;
-      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run;
-      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --no-default-features;
-      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --features i128;
-      $CARGO_CMD bench $TARGET_PARAM --verbose --no-run --no-default-features --features i128;
-    fi
+script: ci/script.sh
 branches:
   only:
     - master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ name = "byteorder"
 bench = false
 
 [dev-dependencies]
-quickcheck = { version = "0.5", default-features = false }
-rand = "0.3"
+quickcheck = { version = "0.6", default-features = false }
+rand = "0.4"
 
 [features]
 default = ["std"]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -ex
+
+# Setup some variables for executing cargo commands.
+# Things are a little different if we're testing with cross.
+if [ ! z "$CROSS_TARGET" ]; then
+  rustup target add "$CROSS_TARGET"
+  cargo install cross --force
+  export CARGO_CMD="cross"
+  export TARGET_PARAM="--target $CROSS_TARGET"
+else
+  export CARGO_CMD="cargo"
+  export TARGET_PARAM=""
+fi
+
+# Test the build and docs.
+"$CARGO_CMD" build --verbose $TARGET_PARAM
+"$CARGO_CMD" doc --verbose $TARGET_PARAM
+
+# If we're testing on an older version of Rust, then only check that we
+# can build the crate. This is because the dev dependencies might be updated
+# more frequently, and therefore might require a newer version of Rust.
+#
+# This isn't ideal. It's a compromise.
+if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
+  exit
+fi
+
+"$CARGO_CMD" test --verbose $TARGET_PARAM
+"$CARGO_CMD" test --verbose --no-default-features --lib $TARGET_PARAM
+if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  "$CARGO_CMD" test \
+    --verbose --features i128 $TARGET_PARAM
+  "$CARGO_CMD" test \
+    --verbose --no-default-features --features i128 --lib $TARGET_PARAM
+  "$CARGO_CMD" bench \
+    --verbose --no-run $TARGET_PARAM
+  "$CARGO_CMD" bench \
+    --verbose --no-run --no-default-features $TARGET_PARAM
+  "$CARGO_CMD" bench \
+    --verbose --no-run --features i128 $TARGET_PARAM
+  "$CARGO_CMD" bench \
+    --verbose --no-run --no-default-features --features i128 $TARGET_PARAM
+fi


### PR DESCRIPTION
This rolls up #110, #113 and #114. It also does a reorg of CI. I'd like to keep updating dev dependencies, but `rand 0.4` requires a version of Rust newer than `1.12`. So we change CI to only make sure that `byteorder` builds on `1.12`, but don't run tests.