### PR TITLE
Use OR in the license field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/BurntSushi/byteorder"
 readme = "README.md"
 categories = ["encoding", "parsing"]
 keywords = ["byte", "endian", "big-endian", "little-endian", "binary"]
-license = "Unlicense/MIT"
+license = "Unlicense OR MIT"
 
 [lib]
 name = "byteorder"


### PR DESCRIPTION
`/` in license field is deprecated and it's generally [recommended](https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata) to use `AND` or `OR` instead.