### PR TITLE
ci: fix [ syntax to run cross CI as cross compilation.

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,7 +4,7 @@ set -ex
 
 # Setup some variables for executing cargo commands.
 # Things are a little different if we're testing with cross.
-if [ ! z "$CROSS_TARGET" ]; then
+if [ ! -z "$CROSS_TARGET" ]; then
   rustup target add "$CROSS_TARGET"
   cargo install cross --force
   export CARGO_CMD="cross"


### PR DESCRIPTION
Previously the [ was just failing with:

+[ ! z mips64-unknown-linux-gnuabi64 ]
ci/script.sh: 7: [: z: unexpected operator

and thus falling through to the `cargo` version.

Fixes https://github.com/BurntSushi/byteorder/issues/134.