### PR TITLE
prep for 1.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+1.3.0
+=====
+This new minor release now enables `i128` support automatically on Rust
+compilers that support 128-bit integers. The `i128` feature is now a no-op, but
+continues to exist for backward compatibility purposes. The crate continues to
+maintain compatibility with Rust 1.12.0.
+
+This release also deprecates the `ByteOrder` trait methods
+`read_f32_into_unchecked` and `read_f64_into_unchecked` in favor of
+`read_f32_into` and `read_f64_into`. This was an oversight from the 1.2 release
+where the corresponding methods on `ReadBytesExt` were deprecated.
+
+`quickcheck` and `rand` were bumped to `0.8` and `0.6`, respectively.
+
+A few small documentation related bugs have been fixed.
+
+
+1.2.7
+=====
+This patch release excludes some CI files from the crate release and updates
+the license field to use `OR` instead of `/`.
+
+
+1.2.6
+=====
+This patch release fixes some test compilation errors introduced by an
+over-eager release of 1.2.5.
+
+
+1.2.5
+=====
+This patch release fixes some typos in the docs, adds doc tests to methods on
+`WriteByteExt` and bumps the quickcheck dependency to `0.7`.
+
+
+1.2.4
+=====
+This patch release adds support for 48-bit integers by adding the following
+methods to the `ByteOrder` trait: `read_u48`, `read_i48`, `write_u48` and
+`write_i48`. Corresponding methods have been added to the `ReadBytesExt` and
+`WriteBytesExt` traits as well.
+
+
 1.2.3
 =====
 This patch release removes the use of `feature(i128_type)` from byteorder,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,10 @@ rand = "0.6"
 [features]
 default = ["std"]
 std = []
+
+# This feature is no longer used and is DEPRECATED. This crate now
+# automatically enables i128 support for Rust compilers that support it. The
+# feature will be removed if and when a new major version is released.
 i128 = []
 
 [profile.bench]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ name = "byteorder"
 bench = false
 
 [dev-dependencies]
-quickcheck = { version = "0.7", default-features = false }
-rand = "0.5"
+quickcheck = { version = "0.8", default-features = false }
+rand = "0.6"
 
 [features]
 default = ["std"]

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -148,108 +148,108 @@ bench_num!(int_6, read_int, 6, [1, 2, 3, 4, 5, 6]);
 bench_num!(int_7, read_int, 7, [1, 2, 3, 4, 5, 6, 7]);
 bench_num!(int_8, read_int, 8, [1, 2, 3, 4, 5, 6, 7, 8]);
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(u128, MAX, read_u128, write_u128,
     16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(i128, MAX, read_i128, write_i128,
     16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_1, read_uint128,
     1, [1]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_2, read_uint128,
     2, [1, 2]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_3, read_uint128,
     3, [1, 2, 3]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_4, read_uint128,
     4, [1, 2, 3, 4]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_5, read_uint128,
     5, [1, 2, 3, 4, 5]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_6, read_uint128,
     6, [1, 2, 3, 4, 5, 6]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_7, read_uint128,
     7, [1, 2, 3, 4, 5, 6, 7]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_8, read_uint128,
     8, [1, 2, 3, 4, 5, 6, 7, 8]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_9, read_uint128,
     9, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_10, read_uint128,
     10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_11, read_uint128,
     11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_12, read_uint128,
     12, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_13, read_uint128,
     13, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_14, read_uint128,
     14, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_15, read_uint128,
     15, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(uint128_16, read_uint128,
     16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_1, read_int128,
     1, [1]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_2, read_int128,
     2, [1, 2]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_3, read_int128,
     3, [1, 2, 3]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_4, read_int128,
     4, [1, 2, 3, 4]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_5, read_int128,
     5, [1, 2, 3, 4, 5]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_6, read_int128,
     6, [1, 2, 3, 4, 5, 6]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_7, read_int128,
     7, [1, 2, 3, 4, 5, 6, 7]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_8, read_int128,
     8, [1, 2, 3, 4, 5, 6, 7, 8]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_9, read_int128,
     9, [1, 2, 3, 4, 5, 6, 7, 8, 9]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_10, read_int128,
     10, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_11, read_int128,
     11, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_12, read_int128,
     12, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_13, read_int128,
     13, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_14, read_int128,
     14, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_15, read_int128,
     15, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]);
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 bench_num!(int128_16, read_int128,
     16, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16]);
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,82 @@
+use std::env;
+use std::ffi::OsString;
+use std::process::Command;
+
+fn main() {
+    let version = match Version::read() {
+        Ok(version) => version,
+        Err(err) => {
+            eprintln!("failed to parse `rustc --version`: {}", err);
+            return;
+        }
+    };
+    enable_i128(version);
+}
+
+fn enable_i128(version: Version) {
+    if version < (Version { major: 1, minor: 26, patch: 0 }) {
+        return;
+    }
+
+    println!("cargo:rustc-cfg=byteorder_i128");
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
+struct Version {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl Version {
+    fn read() -> Result<Version, String> {
+        let rustc = env::var_os("RUSTC").unwrap_or(OsString::from("rustc"));
+        let output = Command::new(&rustc)
+            .arg("--version")
+            .output()
+            .unwrap()
+            .stdout;
+        Version::parse(&String::from_utf8(output).unwrap())
+    }
+
+    fn parse(mut s: &str) -> Result<Version, String> {
+        if !s.starts_with("rustc ") {
+            return Err(format!("unrecognized version string: {}", s));
+        }
+        s = &s["rustc ".len()..];
+
+        let parts: Vec<&str> = s.split(".").collect();
+        if parts.len() < 3 {
+            return Err(format!("not enough version parts: {:?}", parts));
+        }
+
+        let mut num = String::new();
+        for c in parts[0].chars() {
+            if !c.is_digit(10) {
+                break;
+            }
+            num.push(c);
+        }
+        let major = num.parse::<u32>().map_err(|e| e.to_string())?;
+
+        num.clear();
+        for c in parts[1].chars() {
+            if !c.is_digit(10) {
+                break;
+            }
+            num.push(c);
+        }
+        let minor = num.parse::<u32>().map_err(|e| e.to_string())?;
+
+        num.clear();
+        for c in parts[2].chars() {
+            if !c.is_digit(10) {
+                break;
+            }
+            num.push(c);
+        }
+        let patch = num.parse::<u32>().map_err(|e| e.to_string())?;
+
+        Ok(Version { major, minor, patch })
+    }
+}

--- a/src/io.rs
+++ b/src/io.rs
@@ -370,7 +370,7 @@ pub trait ReadBytesExt: io::Read {
     /// ]);
     /// assert_eq!(16947640962301618749969007319746179, rdr.read_u128::<BigEndian>().unwrap());
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128<T: ByteOrder>(&mut self) -> Result<u128> {
         let mut buf = [0; 16];
@@ -391,14 +391,13 @@ pub trait ReadBytesExt: io::Read {
     /// Read a signed 128 bit big-endian integer from a `Read`:
     ///
     /// ```rust
-    /// #![feature(i128_type)]
     /// use std::io::Cursor;
     /// use byteorder::{BigEndian, ReadBytesExt};
     ///
     /// let mut rdr = Cursor::new(vec![0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]);
     /// assert_eq!(i128::min_value(), rdr.read_i128::<BigEndian>().unwrap());
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_i128<T: ByteOrder>(&mut self) -> Result<i128> {
         let mut buf = [0; 16];
@@ -457,7 +456,7 @@ pub trait ReadBytesExt: io::Read {
     }
 
     /// Reads an unsigned n-bytes integer from the underlying reader.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_uint128<T: ByteOrder>(&mut self, nbytes: usize) -> Result<u128> {
         let mut buf = [0; 16];
@@ -466,7 +465,7 @@ pub trait ReadBytesExt: io::Read {
     }
 
     /// Reads a signed n-bytes integer from the underlying reader.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_int128<T: ByteOrder>(&mut self, nbytes: usize) -> Result<i128> {
         let mut buf = [0; 16];
@@ -672,7 +671,7 @@ pub trait ReadBytesExt: io::Read {
     /// rdr.read_u128_into::<BigEndian>(&mut dst).unwrap();
     /// assert_eq!([517, 768], dst);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128_into<T: ByteOrder>(
         &mut self,
@@ -822,7 +821,7 @@ pub trait ReadBytesExt: io::Read {
     /// rdr.read_i128_into::<BigEndian>(&mut dst).unwrap();
     /// assert_eq!([517, 768], dst);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_i128_into<T: ByteOrder>(
         &mut self,
@@ -1373,7 +1372,7 @@ pub trait WriteBytesExt: io::Write {
     }
 
     /// Writes an unsigned 128 bit integer to the underlying writer.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_u128<T: ByteOrder>(&mut self, n: u128) -> Result<()> {
         let mut buf = [0; 16];
@@ -1382,7 +1381,7 @@ pub trait WriteBytesExt: io::Write {
     }
 
     /// Writes a signed 128 bit integer to the underlying writer.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_i128<T: ByteOrder>(&mut self, n: i128) -> Result<()> {
         let mut buf = [0; 16];
@@ -1466,7 +1465,7 @@ pub trait WriteBytesExt: io::Write {
     ///
     /// If the given integer is not representable in the given number of bytes,
     /// this method panics. If `nbytes > 16`, this method panics.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_uint128<T: ByteOrder>(
         &mut self,
@@ -1482,7 +1481,7 @@ pub trait WriteBytesExt: io::Write {
     ///
     /// If the given integer is not representable in the given number of bytes,
     /// this method panics. If `nbytes > 16`, this method panics.
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_int128<T: ByteOrder>(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ fn extend_sign(val: u64, nbytes: usize) -> i64 {
     (val << shift) as i64 >> shift
 }
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 #[inline]
 fn extend_sign128(val: u128, nbytes: usize) -> i128 {
     let shift = (16 - nbytes) * 8;
@@ -97,7 +97,7 @@ fn unextend_sign(val: i64, nbytes: usize) -> u64 {
     (val << shift) as u64 >> shift
 }
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 #[inline]
 fn unextend_sign128(val: i128, nbytes: usize) -> u128 {
     let shift = (16 - nbytes) * 8;
@@ -125,7 +125,7 @@ fn pack_size(n: u64) -> usize {
     }
 }
 
-#[cfg(feature = "i128")]
+#[cfg(byteorder_i128)]
 #[inline]
 fn pack_size128(n: u128) -> usize {
     if n < 1 << 8 {
@@ -314,7 +314,7 @@ pub trait ByteOrder
     /// LittleEndian::write_u128(&mut buf, 1_000_000);
     /// assert_eq!(1_000_000, LittleEndian::read_u128(&buf));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn read_u128(buf: &[u8]) -> u128;
 
     /// Reads an unsigned n-bytes integer from `buf`.
@@ -355,7 +355,7 @@ pub trait ByteOrder
     /// LittleEndian::write_uint128(&mut buf, 1_000_000, 3);
     /// assert_eq!(1_000_000, LittleEndian::read_uint128(&buf, 3));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn read_uint128(buf: &[u8], nbytes: usize) -> u128;
 
     /// Writes an unsigned 16 bit integer `n` to `buf`.
@@ -474,7 +474,7 @@ pub trait ByteOrder
     /// LittleEndian::write_u128(&mut buf, 1_000_000);
     /// assert_eq!(1_000_000, LittleEndian::read_u128(&buf));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn write_u128(buf: &mut [u8], n: u128);
 
     /// Writes an unsigned integer `n` to `buf` using only `nbytes`.
@@ -515,7 +515,7 @@ pub trait ByteOrder
     /// LittleEndian::write_uint128(&mut buf, 1_000_000, 3);
     /// assert_eq!(1_000_000, LittleEndian::read_uint128(&buf, 3));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn write_uint128(buf: &mut [u8], n: u128, nbytes: usize);
 
     /// Reads a signed 16 bit integer from `buf`.
@@ -645,7 +645,7 @@ pub trait ByteOrder
     /// LittleEndian::write_i128(&mut buf, -1_000_000_000);
     /// assert_eq!(-1_000_000_000, LittleEndian::read_i128(&buf));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_i128(buf: &[u8]) -> i128 {
         Self::read_u128(buf) as i128
@@ -692,7 +692,7 @@ pub trait ByteOrder
     /// LittleEndian::write_int128(&mut buf, -1_000, 3);
     /// assert_eq!(-1_000, LittleEndian::read_int128(&buf, 3));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_int128(buf: &[u8], nbytes: usize) -> i128 {
         extend_sign128(Self::read_uint128(buf, nbytes), nbytes)
@@ -871,7 +871,7 @@ pub trait ByteOrder
     /// LittleEndian::write_i128(&mut buf, -1_000_000_000);
     /// assert_eq!(-1_000_000_000, LittleEndian::read_i128(&buf));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_i128(buf: &mut [u8], n: i128) {
         Self::write_u128(buf, n as u128)
@@ -918,7 +918,7 @@ pub trait ByteOrder
     /// LittleEndian::write_int128(&mut buf, -1_000, 3);
     /// assert_eq!(-1_000, LittleEndian::read_int128(&buf, 3));
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_int128(buf: &mut [u8], n: i128, nbytes: usize) {
         Self::write_uint128(buf, unextend_sign128(n, nbytes), nbytes)
@@ -1062,7 +1062,7 @@ pub trait ByteOrder
     /// LittleEndian::read_u128_into(&bytes, &mut numbers_got);
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn read_u128_into(src: &[u8], dst: &mut [u128]);
 
     /// Reads signed 16 bit integers from `src` to `dst`.
@@ -1173,7 +1173,7 @@ pub trait ByteOrder
     /// LittleEndian::read_i128_into(&bytes, &mut numbers_got);
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_i128_into(src: &[u8], dst: &mut [i128]) {
         let dst = unsafe {
@@ -1332,7 +1332,7 @@ pub trait ByteOrder
     /// LittleEndian::read_u128_into(&bytes, &mut numbers_got);
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn write_u128_into(src: &[u128], dst: &mut [u8]);
 
     /// Writes signed 16 bit integers from `src` into `dst`.
@@ -1440,7 +1440,7 @@ pub trait ByteOrder
     /// LittleEndian::read_i128_into(&bytes, &mut numbers_got);
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn write_i128_into(src: &[i128], dst: &mut [u8]) {
         let src = unsafe {
             slice::from_raw_parts(src.as_ptr() as *const u128, src.len())
@@ -1584,7 +1584,7 @@ pub trait ByteOrder
     /// BigEndian::from_slice_u128(&mut numbers);
     /// assert_eq!(numbers, [5u128.to_be(), 65000u128.to_be()]);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     fn from_slice_u128(numbers: &mut [u128]);
 
     /// Converts the given slice of signed 16 bit integers to a particular
@@ -1679,7 +1679,7 @@ pub trait ByteOrder
     /// BigEndian::from_slice_i128(&mut numbers);
     /// assert_eq!(numbers, [5i128.to_be(), 65000i128.to_be()]);
     /// ```
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn from_slice_i128(src: &mut [i128]) {
         let src = unsafe {
@@ -1894,7 +1894,7 @@ impl ByteOrder for BigEndian {
         read_num_bytes!(u64, 8, buf, to_be)
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128(buf: &[u8]) -> u128 {
         read_num_bytes!(u128, 16, buf, to_be)
@@ -1912,7 +1912,7 @@ impl ByteOrder for BigEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_uint128(buf: &[u8], nbytes: usize) -> u128 {
         assert!(1 <= nbytes && nbytes <= 16 && nbytes <= buf.len());
@@ -1940,7 +1940,7 @@ impl ByteOrder for BigEndian {
         write_num_bytes!(u64, 8, n, buf, to_be);
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_u128(buf: &mut [u8], n: u128) {
         write_num_bytes!(u128, 16, n, buf, to_be);
@@ -1959,7 +1959,7 @@ impl ByteOrder for BigEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_uint128(buf: &mut [u8], n: u128, nbytes: usize) {
         assert!(pack_size128(n) <= nbytes && nbytes <= 16);
@@ -1988,7 +1988,7 @@ impl ByteOrder for BigEndian {
         read_slice!(src, dst, 8, to_be);
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128_into(src: &[u8], dst: &mut [u128]) {
         read_slice!(src, dst, 16, to_be);
@@ -2021,7 +2021,7 @@ impl ByteOrder for BigEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_u128_into(src: &[u128], dst: &mut [u8]) {
         if cfg!(target_endian = "big") {
@@ -2058,7 +2058,7 @@ impl ByteOrder for BigEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn from_slice_u128(numbers: &mut [u128]) {
         if cfg!(target_endian = "little") {
@@ -2109,7 +2109,7 @@ impl ByteOrder for LittleEndian {
         read_num_bytes!(u64, 8, buf, to_le)
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128(buf: &[u8]) -> u128 {
         read_num_bytes!(u128, 16, buf, to_le)
@@ -2126,7 +2126,7 @@ impl ByteOrder for LittleEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_uint128(buf: &[u8], nbytes: usize) -> u128 {
         assert!(1 <= nbytes && nbytes <= 16 && nbytes <= buf.len());
@@ -2153,7 +2153,7 @@ impl ByteOrder for LittleEndian {
         write_num_bytes!(u64, 8, n, buf, to_le);
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_u128(buf: &mut [u8], n: u128) {
         write_num_bytes!(u128, 16, n, buf, to_le);
@@ -2169,7 +2169,7 @@ impl ByteOrder for LittleEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_uint128(buf: &mut [u8], n: u128, nbytes: usize) {
         assert!(pack_size128(n as u128) <= nbytes && nbytes <= 16);
@@ -2195,7 +2195,7 @@ impl ByteOrder for LittleEndian {
         read_slice!(src, dst, 8, to_le);
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn read_u128_into(src: &[u8], dst: &mut [u128]) {
         read_slice!(src, dst, 16, to_le);
@@ -2228,7 +2228,7 @@ impl ByteOrder for LittleEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn write_u128_into(src: &[u128], dst: &mut [u8]) {
         if cfg!(target_endian = "little") {
@@ -2265,7 +2265,7 @@ impl ByteOrder for LittleEndian {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     #[inline]
     fn from_slice_u128(numbers: &mut [u128]) {
         if cfg!(target_endian = "big") {
@@ -2307,7 +2307,10 @@ mod test {
 
     use self::quickcheck::{QuickCheck, StdGen, Testable};
     use self::rand::thread_rng;
-    #[cfg(feature = "i128")] use self::quickcheck::{Arbitrary, Gen};
+    #[cfg(byteorder_i128)]
+    use self::rand::Rng;
+    #[cfg(byteorder_i128)]
+    use self::quickcheck::{Arbitrary, Gen};
 
     pub const U24_MAX: u32 = 16_777_215;
     pub const I24_MAX: i32 = 8_388_607;
@@ -2327,7 +2330,7 @@ mod test {
     #[derive(Clone, Debug)]
     pub struct Wi128<T>(pub T);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     impl<T: Clone> Wi128<T> {
         pub fn clone(&self) -> T {
             self.0.clone()
@@ -2340,7 +2343,7 @@ mod test {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     impl Arbitrary for Wi128<u128> {
         fn arbitrary<G: Gen>(gen: &mut G) -> Wi128<u128> {
             let max = calc_max!(::core::u128::MAX, gen.size(), 16);
@@ -2351,7 +2354,7 @@ mod test {
         }
     }
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     impl Arbitrary for Wi128<i128> {
         fn arbitrary<G: Gen>(gen: &mut G) -> Wi128<i128> {
             let max = calc_max!(::core::i128::MAX, gen.size(), 16);
@@ -2464,9 +2467,9 @@ mod test {
     qc_byte_order!(prop_f32, f32, ::core::u64::MAX as u64, read_f32, write_f32);
     qc_byte_order!(prop_f64, f64, ::core::i64::MAX as u64, read_f64, write_f64);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_u128, Wi128<u128>, 16 + 1, read_u128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_i128, Wi128<i128>, 16 + 1, read_i128, write_i128);
 
     qc_byte_order!(prop_uint_1,
@@ -2486,52 +2489,52 @@ mod test {
     qc_byte_order!(prop_uint_8,
         u64, calc_max!(super::U64_MAX, 8), 8, read_uint, write_uint);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_1,
         Wi128<u128>, 1, 1, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_2,
         Wi128<u128>, 2, 2, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_3,
         Wi128<u128>, 3, 3, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_4,
         Wi128<u128>, 4, 4, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_5,
         Wi128<u128>, 5, 5, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_6,
         Wi128<u128>, 6, 6, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_7,
         Wi128<u128>, 7, 7, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_8,
         Wi128<u128>, 8, 8, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_9,
         Wi128<u128>, 9, 9, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_10,
         Wi128<u128>, 10, 10, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_11,
         Wi128<u128>, 11, 11, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_12,
         Wi128<u128>, 12, 12, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_13,
         Wi128<u128>, 13, 13, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_14,
         Wi128<u128>, 14, 14, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_15,
         Wi128<u128>, 15, 15, read_uint128, write_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_uint128_16,
         Wi128<u128>, 16, 16, read_uint128, write_uint128);
 
@@ -2552,52 +2555,52 @@ mod test {
     qc_byte_order!(prop_int_8,
         i64, calc_max!(super::I64_MAX, 8), 8, read_int, write_int);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_1,
         Wi128<i128>, 1, 1, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_2,
         Wi128<i128>, 2, 2, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_3,
         Wi128<i128>, 3, 3, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_4,
         Wi128<i128>, 4, 4, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_5,
         Wi128<i128>, 5, 5, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_6,
         Wi128<i128>, 6, 6, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_7,
         Wi128<i128>, 7, 7, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_8,
         Wi128<i128>, 8, 8, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_9,
         Wi128<i128>, 9, 9, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_10,
         Wi128<i128>, 10, 10, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_11,
         Wi128<i128>, 11, 11, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_12,
         Wi128<i128>, 12, 12, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_13,
         Wi128<i128>, 13, 13, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_14,
         Wi128<i128>, 14, 14, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_15,
         Wi128<i128>, 15, 15, read_int128, write_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_byte_order!(prop_int128_16,
         Wi128<i128>, 16, 16, read_int128, write_int128);
 
@@ -2692,9 +2695,9 @@ mod test {
     too_small!(small_i64, 7, 0, read_i64, write_i64);
     too_small!(small_f32, 3, 0.0, read_f32, write_f32);
     too_small!(small_f64, 7, 0.0, read_f64, write_f64);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_u128, 15, 0, read_u128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_i128, 15, 0, read_i128, write_i128);
 
     too_small!(small_uint_1, 1, read_uint);
@@ -2705,35 +2708,35 @@ mod test {
     too_small!(small_uint_6, 6, read_uint);
     too_small!(small_uint_7, 7, read_uint);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_1, 1, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_2, 2, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_3, 3, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_4, 4, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_5, 5, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_6, 6, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_7, 7, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_8, 8, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_9, 9, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_10, 10, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_11, 11, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_12, 12, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_13, 13, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_14, 14, read_uint128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_uint128_15, 15, read_uint128);
 
     too_small!(small_int_1, 1, read_int);
@@ -2744,35 +2747,35 @@ mod test {
     too_small!(small_int_6, 6, read_int);
     too_small!(small_int_7, 7, read_int);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_1, 1, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_2, 2, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_3, 3, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_4, 4, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_5, 5, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_6, 6, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_7, 7, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_8, 8, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_9, 9, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_10, 10, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_11, 11, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_12, 12, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_13, 13, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_14, 14, read_int128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     too_small!(small_int128_15, 15, read_int128);
 
     // Test that reading/writing slices enforces the correct lengths.
@@ -2860,16 +2863,16 @@ mod test {
     slice_lengths!(
         slice_len_too_big_i64, read_i64_into, write_i64_into, 17, [0, 0]);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     slice_lengths!(
         slice_len_too_small_u128, read_u128_into, write_u128_into, 31, [0, 0]);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     slice_lengths!(
         slice_len_too_big_u128, read_u128_into, write_u128_into, 33, [0, 0]);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     slice_lengths!(
         slice_len_too_small_i128, read_i128_into, write_i128_into, 31, [0, 0]);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     slice_lengths!(
         slice_len_too_big_i128, read_i128_into, write_i128_into, 33, [0, 0]);
 
@@ -3016,9 +3019,9 @@ mod stdtests {
     qc_bytes_ext!(prop_ext_f64,
         f64, ::std::i64::MAX as u64, read_f64, write_f64);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_u128, Wi128<u128>, 16 + 1, read_u128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_i128, Wi128<i128>, 16 + 1, read_i128, write_i128);
 
     qc_bytes_ext!(prop_ext_uint_1,
@@ -3038,52 +3041,52 @@ mod stdtests {
     qc_bytes_ext!(prop_ext_uint_8,
         u64, calc_max!(::test::U64_MAX, 8), 8, read_uint, write_u64);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_1,
         Wi128<u128>, 1, 1, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_2,
         Wi128<u128>, 2, 2, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_3,
         Wi128<u128>, 3, 3, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_4,
         Wi128<u128>, 4, 4, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_5,
         Wi128<u128>, 5, 5, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_6,
         Wi128<u128>, 6, 6, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_7,
         Wi128<u128>, 7, 7, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_8,
         Wi128<u128>, 8, 8, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_9,
         Wi128<u128>, 9, 9, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_10,
         Wi128<u128>, 10, 10, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_11,
         Wi128<u128>, 11, 11, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_12,
         Wi128<u128>, 12, 12, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_13,
         Wi128<u128>, 13, 13, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_14,
         Wi128<u128>, 14, 14, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_15,
         Wi128<u128>, 15, 15, read_uint128, write_u128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_uint128_16,
         Wi128<u128>, 16, 16, read_uint128, write_u128);
 
@@ -3104,52 +3107,52 @@ mod stdtests {
     qc_bytes_ext!(prop_ext_int_8,
         i64, calc_max!(::test::I64_MAX, 8), 8, read_int, write_i64);
 
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_1,
         Wi128<i128>, 1, 1, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_2,
         Wi128<i128>, 2, 2, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_3,
         Wi128<i128>, 3, 3, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_4,
         Wi128<i128>, 4, 4, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_5,
         Wi128<i128>, 5, 5, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_6,
         Wi128<i128>, 6, 6, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_7,
         Wi128<i128>, 7, 7, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_8,
         Wi128<i128>, 8, 8, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_9,
         Wi128<i128>, 9, 9, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_10,
         Wi128<i128>, 10, 10, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_11,
         Wi128<i128>, 11, 11, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_12,
         Wi128<i128>, 12, 12, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_13,
         Wi128<i128>, 13, 13, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_14,
         Wi128<i128>, 14, 14, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_15,
         Wi128<i128>, 15, 15, read_int128, write_i128);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_bytes_ext!(prop_ext_int128_16,
         Wi128<i128>, 16, 16, read_int128, write_i128);
 
@@ -3235,10 +3238,10 @@ mod stdtests {
     qc_slice!(prop_slice_i32, i32, read_i32_into, write_i32_into, 0);
     qc_slice!(prop_slice_u64, u64, read_u64_into, write_u64_into, 0);
     qc_slice!(prop_slice_i64, i64, read_i64_into, write_i64_into, 0);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_slice!(
         prop_slice_u128, Wi128<u128>, read_u128_into, write_u128_into, 0);
-    #[cfg(feature = "i128")]
+    #[cfg(byteorder_i128)]
     qc_slice!(
         prop_slice_i128, Wi128<i128>, read_i128_into, write_i128_into, 0);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1201,17 +1201,82 @@ pub trait ByteOrder
     /// LittleEndian::write_f32_into(&numbers_given, &mut bytes);
     ///
     /// let mut numbers_got = [0.0; 4];
-    /// LittleEndian::read_f32_into_unchecked(&bytes, &mut numbers_got);
+    /// LittleEndian::read_f32_into(&bytes, &mut numbers_got);
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
     #[inline]
-    fn read_f32_into_unchecked(src: &[u8], dst: &mut [f32]) {
+    fn read_f32_into(src: &[u8], dst: &mut [f32]) {
         let dst = unsafe {
             slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u32, dst.len())
         };
         Self::read_u32_into(src, dst);
     }
 
+    /// **DEPRECATED**.
+    ///
+    /// This method is deprecated. Use `read_f32_into` instead.
+    /// Reads IEEE754 single-precision (4 bytes) floating point numbers from
+    /// `src` into `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `src.len() != 4*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f32` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut bytes = [0; 16];
+    /// let numbers_given = [1.0, 2.0, 31.312e31, -11.32e19];
+    /// LittleEndian::write_f32_into(&numbers_given, &mut bytes);
+    ///
+    /// let mut numbers_got = [0.0; 4];
+    /// LittleEndian::read_f32_into_unchecked(&bytes, &mut numbers_got);
+    /// assert_eq!(numbers_given, numbers_got);
+    /// ```
+    #[inline]
+    #[deprecated(since="1.3.0", note="please use `read_f32_into` instead")]
+    fn read_f32_into_unchecked(src: &[u8], dst: &mut [f32]) {
+        Self::read_f32_into(src, dst);
+    }
+
+    /// Reads IEEE754 single-precision (4 bytes) floating point numbers from
+    /// `src` into `dst`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `src.len() != 8*dst.len()`.
+    ///
+    /// # Examples
+    ///
+    /// Write and read `f64` numbers in little endian order:
+    ///
+    /// ```rust
+    /// use byteorder::{ByteOrder, LittleEndian};
+    ///
+    /// let mut bytes = [0; 32];
+    /// let numbers_given = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// LittleEndian::write_f64_into(&numbers_given, &mut bytes);
+    ///
+    /// let mut numbers_got = [0.0; 4];
+    /// LittleEndian::read_f64_into(&bytes, &mut numbers_got);
+    /// assert_eq!(numbers_given, numbers_got);
+    /// ```
+    #[inline]
+    fn read_f64_into(src: &[u8], dst: &mut [f64]) {
+        let dst = unsafe {
+            slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
+        };
+        Self::read_u64_into(src, dst);
+    }
+
+    /// **DEPRECATED**.
+    ///
+    /// This method is deprecated. Use `read_f64_into` instead.
+    ///
     /// Reads IEEE754 single-precision (4 bytes) floating point numbers from
     /// `src` into `dst`.
     ///
@@ -1235,11 +1300,9 @@ pub trait ByteOrder
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
     #[inline]
+    #[deprecated(since="1.3.0", note="please use `read_f64_into` instead")]
     fn read_f64_into_unchecked(src: &[u8], dst: &mut [f64]) {
-        let dst = unsafe {
-            slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
-        };
-        Self::read_u64_into(src, dst);
+        Self::read_f64_into(src, dst);
     }
 
     /// Writes unsigned 16 bit integers from `src` into `dst`.
@@ -1468,7 +1531,7 @@ pub trait ByteOrder
     ///
     /// let mut numbers_got = [0.0; 4];
     /// unsafe {
-    ///     LittleEndian::read_f32_into_unchecked(&bytes, &mut numbers_got);
+    ///     LittleEndian::read_f32_into(&bytes, &mut numbers_got);
     /// }
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
@@ -1499,7 +1562,7 @@ pub trait ByteOrder
     ///
     /// let mut numbers_got = [0.0; 4];
     /// unsafe {
-    ///     LittleEndian::read_f64_into_unchecked(&bytes, &mut numbers_got);
+    ///     LittleEndian::read_f64_into(&bytes, &mut numbers_got);
     /// }
     /// assert_eq!(numbers_given, numbers_got);
     /// ```
@@ -3246,7 +3309,7 @@ mod stdtests {
         prop_slice_i128, Wi128<i128>, read_i128_into, write_i128_into, 0);
 
     qc_slice!(
-        prop_slice_f32, f32, read_f32_into_unchecked, write_f32_into, 0.0);
+        prop_slice_f32, f32, read_f32_into, write_f32_into, 0.0);
     qc_slice!(
-        prop_slice_f64, f64, read_f64_into_unchecked, write_f64_into, 0.0);
+        prop_slice_f64, f64, read_f64_into, write_f64_into, 0.0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1197,7 +1197,7 @@ pub trait ByteOrder
     /// use byteorder::{ByteOrder, LittleEndian};
     ///
     /// let mut bytes = [0; 16];
-    /// let numbers_given = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// let numbers_given = [1.0, 2.0, 31.312e31, -11.32e19];
     /// LittleEndian::write_f32_into(&numbers_given, &mut bytes);
     ///
     /// let mut numbers_got = [0.0; 4];
@@ -1463,7 +1463,7 @@ pub trait ByteOrder
     /// use byteorder::{ByteOrder, LittleEndian};
     ///
     /// let mut bytes = [0; 16];
-    /// let numbers_given = [1.0, 2.0, 31.312e311, -11.32e91];
+    /// let numbers_given = [1.0, 2.0, 31.312e31, -11.32e19];
     /// LittleEndian::write_f32_into(&numbers_given, &mut bytes);
     ///
     /// let mut numbers_got = [0.0; 4];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2306,7 +2306,7 @@ mod test {
     extern crate rand;
 
     use self::quickcheck::{QuickCheck, StdGen, Testable};
-    use self::rand::{Rng, thread_rng};
+    use self::rand::thread_rng;
     #[cfg(feature = "i128")] use self::quickcheck::{Arbitrary, Gen};
 
     pub const U24_MAX: u32 = 16_777_215;


### PR DESCRIPTION
This PR fixes a few small bugs, deprecates `read_{f32,f64}_into_unchecked` (in favor of `read_{f32,f64}_into`) and automatically enables `i128` support for Rust compilers that have it.

ref https://github.com/TyOverby/bincode/issues/250