### PR TITLE
fix build for rustc versions 1.17.0 and 1.18.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["encoding", "parsing"]
 keywords = ["byte", "endian", "big-endian", "little-endian", "binary"]
 license = "Unlicense OR MIT"
 exclude = ["/ci/*"]
+build = "build.rs"
 
 [lib]
 name = "byteorder"

--- a/build.rs
+++ b/build.rs
@@ -1,12 +1,15 @@
 use std::env;
 use std::ffi::OsString;
+use std::io::{self, Write};
 use std::process::Command;
 
 fn main() {
     let version = match Version::read() {
         Ok(version) => version,
         Err(err) => {
-            eprintln!("failed to parse `rustc --version`: {}", err);
+            writeln!(&mut io::stderr(),
+                "failed to parse `rustc --version`: {}", err)
+                .unwrap();
             return;
         }
     };
@@ -57,7 +60,7 @@ impl Version {
             }
             num.push(c);
         }
-        let major = num.parse::<u32>().map_err(|e| e.to_string())?;
+        let major = try!(num.parse::<u32>().map_err(|e| e.to_string()));
 
         num.clear();
         for c in parts[1].chars() {
@@ -66,7 +69,7 @@ impl Version {
             }
             num.push(c);
         }
-        let minor = num.parse::<u32>().map_err(|e| e.to_string())?;
+        let minor = try!(num.parse::<u32>().map_err(|e| e.to_string()));
 
         num.clear();
         for c in parts[2].chars() {
@@ -75,8 +78,8 @@ impl Version {
             }
             num.push(c);
         }
-        let patch = num.parse::<u32>().map_err(|e| e.to_string())?;
+        let patch = try!(num.parse::<u32>().map_err(|e| e.to_string()));
 
-        Ok(Version { major, minor, patch })
+        Ok(Version { major: major, minor: minor, patch: patch })
     }
 }


### PR DESCRIPTION
Include build.rs in Cargo.toml to make sure the 1.12.0 test uses build.rs during building. Then fix build.rs to be compatible with rustc version 1.12.0.

Fixes #140. The bug was not caught by the tests since build.rs was not autodetected in 1.12.0, but was autodetected for 1.17.0 and 1.18.0.