### PR TITLE
Add read_i8_into to ReadBytesExt

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -535,38 +535,6 @@ pub trait ReadBytesExt: io::Read {
         Ok(T::read_f64(&buf))
     }
 
-    /// Reads a sequence of unsigned 8 bit integers from the underlying reader.
-    ///
-    /// The given buffer is either filled completely or an error is returned.
-    /// If an error is returned, the contents of `dst` are unspecified.
-    ///
-    /// Note that since each `u8` is a single byte, no byte order conversions
-    /// are used. It is included for completeness.
-    ///
-    /// # Errors
-    ///
-    /// This method returns the same errors as [`Read::read_exact`].
-    ///
-    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
-    ///
-    /// # Examples
-    ///
-    /// Read a sequence of unsigned 8 bit integers from a `Read`:
-    ///
-    /// ```rust
-    /// use std::io::Cursor;
-    /// use byteorder::{BigEndian, ReadBytesExt};
-    ///
-    /// let mut rdr = Cursor::new(vec![2, 5, 3]);
-    /// let mut dst = [0; 3];
-    /// rdr.read_u8_into(&mut dst).unwrap();
-    /// assert_eq!([2, 5, 3], dst);
-    /// ```
-    #[inline]
-    fn read_u8_into(&mut self, dst: &mut [u8]) -> Result<()> {
-        self.read_exact(dst)
-    }
-
     /// Reads a sequence of unsigned 16 bit integers from the underlying
     /// reader.
     ///

--- a/src/io.rs
+++ b/src/io.rs
@@ -691,7 +691,10 @@ pub trait ReadBytesExt: io::Read {
     /// If an error is returned, the contents of `dst` are unspecified.
     ///
     /// Note that since each `i8` is a single byte, no byte order conversions
-    /// are used. It is included for completeness.
+    /// are used. This method is included because it provides a safe, simple
+    /// way for the caller to read into a `&mut [i8]` buffer. (Without this
+    /// method, the caller would have to either use `unsafe` code or convert
+    /// each byte to `i8` individually.)
     ///
     /// # Errors
     ///

--- a/src/io.rs
+++ b/src/io.rs
@@ -535,6 +535,38 @@ pub trait ReadBytesExt: io::Read {
         Ok(T::read_f64(&buf))
     }
 
+    /// Reads a sequence of unsigned 8 bit integers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// Note that since each `u8` is a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of unsigned 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 5, 3]);
+    /// let mut dst = [0; 3];
+    /// rdr.read_u8_into(&mut dst).unwrap();
+    /// assert_eq!([2, 5, 3], dst);
+    /// ```
+    #[inline]
+    fn read_u8_into(&mut self, dst: &mut [u8]) -> Result<()> {
+        self.read_exact(dst)
+    }
+
     /// Reads a sequence of unsigned 16 bit integers from the underlying
     /// reader.
     ///
@@ -683,6 +715,39 @@ pub trait ReadBytesExt: io::Read {
         }
         T::from_slice_u128(dst);
         Ok(())
+    }
+
+    /// Reads a sequence of signed 8 bit integers from the underlying reader.
+    ///
+    /// The given buffer is either filled completely or an error is returned.
+    /// If an error is returned, the contents of `dst` are unspecified.
+    ///
+    /// Note that since each `i8` is a single byte, no byte order conversions
+    /// are used. It is included for completeness.
+    ///
+    /// # Errors
+    ///
+    /// This method returns the same errors as [`Read::read_exact`].
+    ///
+    /// [`Read::read_exact`]: https://doc.rust-lang.org/std/io/trait.Read.html#method.read_exact
+    ///
+    /// # Examples
+    ///
+    /// Read a sequence of signed 8 bit integers from a `Read`:
+    ///
+    /// ```rust
+    /// use std::io::Cursor;
+    /// use byteorder::{BigEndian, ReadBytesExt};
+    ///
+    /// let mut rdr = Cursor::new(vec![2, 251, 3]);
+    /// let mut dst = [0; 3];
+    /// rdr.read_i8_into(&mut dst).unwrap();
+    /// assert_eq!([2, -5, 3], dst);
+    /// ```
+    #[inline]
+    fn read_i8_into(&mut self, dst: &mut [i8]) -> Result<()> {
+        let buf = unsafe { slice_to_u8_mut(dst) };
+        self.read_exact(buf)
     }
 
     /// Reads a sequence of signed 16 bit integers from the underlying


### PR DESCRIPTION
These methods are analogous to the already-existing `read_u8` and `read_i8` methods on `ReadBytesExt`. The `read_u8_into` method is primarily useful just for completeness, since it's equivalent to `read_exact`, but the `read_i8_into` method is useful for client code that wants to avoid `unsafe`.