### PR TITLE
note new standard methods from Rust 1.32 in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-This crate provides convenience methods for encoding and decoding numbers in
-either big-endian or little-endian order.
+This crate provides convenience methods for encoding and decoding
+numbers in either big-endian or little-endian order. Note that as of
+Rust 1.32, the standard numeric types provide built-in methods like
+`to_le_bytes` and `from_le_bytes`, which support some of the same use
+cases.
 
 [![Build status](https://api.travis-ci.org/BurntSushi/byteorder.svg)](https://travis-ci.org/BurntSushi/byteorder)
 [![](http://meritbadge.herokuapp.com/byteorder)](https://crates.io/crates/byteorder)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 /*!
-This crate provides convenience methods for encoding and decoding numbers
-in either [big-endian or little-endian order].
+This crate provides convenience methods for encoding and decoding numbers in
+either [big-endian or little-endian order]. Note that as of Rust 1.32, the
+standard numeric types provide built-in methods like `to_le_bytes` and
+`from_le_bytes`, which support some of the same use cases.
 
 The organization of the crate is pretty simple. A trait, [`ByteOrder`], specifies
 byte conversion methods for each type of number in Rust (sans numbers that have


### PR DESCRIPTION
Now that the standard library supports a lot of byte conversion use cases, it might be helpful to newer users to steer them in that direction.