### PR TITLE
Check rustc version using rustc_version crate and fix 1.26.0-nightly build regression

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
 }
 
 fn enable_i128(version: Version) {
-    if version < (Version { major: 1, minor: 26, patch: 0 }) {
+    if version < (Version { major: 1, minor: 26, patch: 0, stable: true }) {
         return;
     }
 
@@ -31,6 +31,7 @@ struct Version {
     major: u32,
     minor: u32,
     patch: u32,
+    stable: bool,
 }
 
 impl Version {
@@ -82,6 +83,8 @@ impl Version {
         }
         let patch = try!(num.parse::<u32>().map_err(|e| e.to_string()));
 
-        Ok(Version { major: major, minor: minor, patch: patch })
+        let stable = !parts[2].contains("-nightly") && !parts[2].contains("-beta");
+
+        Ok(Version { major: major, minor: minor, patch: patch, stable: stable })
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,10 @@ struct Version {
     major: u32,
     minor: u32,
     patch: u32,
+    // true if version is in stable release channel, false if beta or rc
+    // release channel
+    // Note: stable version is greater than unstable one in derivered Ord
+    // implementation
     stable: bool,
 }
 
@@ -83,8 +87,15 @@ impl Version {
         }
         let patch = try!(num.parse::<u32>().map_err(|e| e.to_string()));
 
-        let stable = !parts[2].contains("-nightly") && !parts[2].contains("-beta");
+        let stable =
+            !parts[2].contains("-nightly") &&
+            !parts[2].contains("-beta");
 
-        Ok(Version { major: major, minor: minor, patch: patch, stable: stable })
+        Ok(Version {
+            major: major,
+            minor: minor,
+            patch: patch,
+            stable: stable
+        })
     }
 }

--- a/build.rs
+++ b/build.rs
@@ -31,8 +31,8 @@ struct Version {
     major: u32,
     minor: u32,
     patch: u32,
-    // true if version is in stable release channel, false if beta or rc
-    // release channel
+    // true if version is in stable release channel, false if beta or nightly
+    // channel
     // Note: stable version is greater than unstable one in derivered Ord
     // implementation
     stable: bool,


### PR DESCRIPTION
Fixes build for rustc 1.26.0 nightlies and greatly simplifies the code.
I need it in fatfs create to fix build against rustc 1.26.0-nightly (2789b067d 2018-03-06) (it is required by core_io crate which is used by me for no_std support). This is clearly a regression because it worked fine before addition of i128 types support.
My change greatly simplifies the code as a bonus.