### PR TITLE
ci: change MSRV back to 1.12.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-18.04
-          rust: 1.28.0
+          rust: 1.12.0
         - build: stable
           os: ubuntu-18.04
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ bench = false
 [dev-dependencies]
 quickcheck = { version = "0.8", default-features = false }
 rand = "0.6"
-doc-comment = "0.3"
 
 [features]
 default = ["std"]
@@ -33,6 +32,3 @@ i128 = []
 
 [profile.bench]
 opt-level = 3
-
-[badges]
-travis-ci = { repository = "BurntSushi/byteorder" }

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ If you want to augment existing `Read` and `Write` traits, then import the
 extension methods like so:
 
 ```rust
-extern crate byteorder;
-
 use byteorder::{ReadBytesExt, WriteBytesExt, BigEndian, LittleEndian};
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,13 +75,6 @@ cases.
 #[cfg(feature = "std")]
 extern crate core;
 
-#[cfg(test)]
-#[macro_use]
-extern crate doc_comment;
-
-#[cfg(test)]
-doctest!("../README.md");
-
 use core::fmt::Debug;
 use core::hash::Hash;
 use core::ptr::copy_nonoverlapping;


### PR DESCRIPTION
Setting the pinned version to 1.28.0 was an oversight. It was most
likely the result of a copy & paste error in #159.

We also remove doc_comment, since its MSRV is quite high.

Thanks to @ZoeyR for [pointing this out](https://github.com/BurntSushi/byteorder/pull/159#issuecomment-604224759).