### PR TITLE
Change as_ptr to as_mut_ptr to fix Miri error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1692,7 +1692,7 @@ pub trait ByteOrder:
     #[inline]
     fn from_slice_i16(src: &mut [i16]) {
         let src = unsafe {
-            slice::from_raw_parts_mut(src.as_ptr() as *mut u16, src.len())
+            slice::from_raw_parts_mut(src.as_mut_ptr() as *mut u16, src.len())
         };
         Self::from_slice_u16(src);
     }
@@ -1717,7 +1717,7 @@ pub trait ByteOrder:
     #[inline]
     fn from_slice_i32(src: &mut [i32]) {
         let src = unsafe {
-            slice::from_raw_parts_mut(src.as_ptr() as *mut u32, src.len())
+            slice::from_raw_parts_mut(src.as_mut_ptr() as *mut u32, src.len())
         };
         Self::from_slice_u32(src);
     }
@@ -1742,7 +1742,7 @@ pub trait ByteOrder:
     #[inline]
     fn from_slice_i64(src: &mut [i64]) {
         let src = unsafe {
-            slice::from_raw_parts_mut(src.as_ptr() as *mut u64, src.len())
+            slice::from_raw_parts_mut(src.as_mut_ptr() as *mut u64, src.len())
         };
         Self::from_slice_u64(src);
     }
@@ -1767,7 +1767,7 @@ pub trait ByteOrder:
     #[inline]
     fn from_slice_i128(src: &mut [i128]) {
         let src = unsafe {
-            slice::from_raw_parts_mut(src.as_ptr() as *mut u128, src.len())
+            slice::from_raw_parts_mut(src.as_mut_ptr() as *mut u128, src.len())
         };
         Self::from_slice_u128(src);
     }


### PR DESCRIPTION
Before, the example in the docs for `ByteOrder::from_slice_i32` caused Miri to error with the message, "error: Undefined Behavior: trying to reborrow for Unique at alloc1389, but parent tag <untagged> does not have an appropriate item in the borrow stack". Now it runs without errors (tested locally by creating an example and running it with `cargo +nightly miri run --example the_example`).

([This is the example in the Rust Playground.](https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=d241757cc72e45a5d5e08a7084bb3065) You can run it with Miri by selecting "Miri" from the "Tools" menu.)

Fwiw, I'm not sure if the original code really has undefined behavior or not, but this PR is a simple change, and the new code is a little clearer anyway.