### PR TITLE
Convert endianess while copying in read/write into methods

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -321,4 +321,6 @@ macro_rules! bench_slice {
     };
 }
 
+bench_slice!(slice_u16, u16, read_u16_into, write_u16_into);
 bench_slice!(slice_u64, u64, read_u64_into, write_u64_into);
+bench_slice!(slice_i64, i64, read_i64_into, write_i64_into);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1929,27 +1929,6 @@ macro_rules! read_slice {
     }};
 }
 
-/// Copies a &[$ty] $src into a &mut [u8] $dst, where $ty must be a numeric
-/// type. This panics if size_of::<$ty>() * $src.len() != $dst.len().
-///
-/// This macro is only safe to call when $src is a slice of numeric types and
-/// $dst is a &mut [u8] and where $ty represents the type of the integers in
-/// $src.
-macro_rules! unsafe_write_slice_native {
-    ($src:expr, $dst:expr, $ty:ty) => {{
-        let size = core::mem::size_of::<$ty>();
-        assert_eq!(size * $src.len(), $dst.len());
-
-        unsafe {
-            copy_nonoverlapping(
-                $src.as_ptr() as *const u8,
-                $dst.as_mut_ptr(),
-                $dst.len(),
-            );
-        }
-    }};
-}
-
 macro_rules! write_slice {
     ($src:expr, $dst:expr, $ty:ty, $size:expr, $write:expr) => {{
         assert!($size == ::core::mem::size_of::<$ty>());
@@ -2082,38 +2061,22 @@ impl ByteOrder for BigEndian {
 
     #[inline]
     fn write_u16_into(src: &[u16], dst: &mut [u8]) {
-        if cfg!(target_endian = "big") {
-            unsafe_write_slice_native!(src, dst, u16);
-        } else {
-            write_slice!(src, dst, u16, 2, Self::write_u16);
-        }
+        write_slice!(src, dst, u16, 2, Self::write_u16);
     }
 
     #[inline]
     fn write_u32_into(src: &[u32], dst: &mut [u8]) {
-        if cfg!(target_endian = "big") {
-            unsafe_write_slice_native!(src, dst, u32);
-        } else {
-            write_slice!(src, dst, u32, 4, Self::write_u32);
-        }
+        write_slice!(src, dst, u32, 4, Self::write_u32);
     }
 
     #[inline]
     fn write_u64_into(src: &[u64], dst: &mut [u8]) {
-        if cfg!(target_endian = "big") {
-            unsafe_write_slice_native!(src, dst, u64);
-        } else {
-            write_slice!(src, dst, u64, 8, Self::write_u64);
-        }
+        write_slice!(src, dst, u64, 8, Self::write_u64);
     }
 
     #[inline]
     fn write_u128_into(src: &[u128], dst: &mut [u8]) {
-        if cfg!(target_endian = "big") {
-            unsafe_write_slice_native!(src, dst, u128);
-        } else {
-            write_slice!(src, dst, u128, 16, Self::write_u128);
-        }
+        write_slice!(src, dst, u128, 16, Self::write_u128);
     }
 
     #[inline]
@@ -2282,38 +2245,22 @@ impl ByteOrder for LittleEndian {
 
     #[inline]
     fn write_u16_into(src: &[u16], dst: &mut [u8]) {
-        if cfg!(target_endian = "little") {
-            unsafe_write_slice_native!(src, dst, u16);
-        } else {
-            write_slice!(src, dst, u16, 2, Self::write_u16);
-        }
+        write_slice!(src, dst, u16, 2, Self::write_u16);
     }
 
     #[inline]
     fn write_u32_into(src: &[u32], dst: &mut [u8]) {
-        if cfg!(target_endian = "little") {
-            unsafe_write_slice_native!(src, dst, u32);
-        } else {
-            write_slice!(src, dst, u32, 4, Self::write_u32);
-        }
+        write_slice!(src, dst, u32, 4, Self::write_u32);
     }
 
     #[inline]
     fn write_u64_into(src: &[u64], dst: &mut [u8]) {
-        if cfg!(target_endian = "little") {
-            unsafe_write_slice_native!(src, dst, u64);
-        } else {
-            write_slice!(src, dst, u64, 8, Self::write_u64);
-        }
+        write_slice!(src, dst, u64, 8, Self::write_u64);
     }
 
     #[inline]
     fn write_u128_into(src: &[u128], dst: &mut [u8]) {
-        if cfg!(target_endian = "little") {
-            unsafe_write_slice_native!(src, dst, u128);
-        } else {
-            write_slice!(src, dst, u128, 16, Self::write_u128);
-        }
+        write_slice!(src, dst, u128, 16, Self::write_u128);
     }
 
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1912,25 +1912,19 @@ macro_rules! unsafe_write_num_bytes {
     }};
 }
 
-/// Copies a &[u8] $src into a &mut [<numeric>] $dst for the endianness given
-/// by $which (must be either to_be or to_le).
+/// Copies a &[u8] $src into a &mut [$ty] $dst for the endianness given by
+/// $from_bytes (must be either from_be_bytes or from_le_bytes).
 ///
-/// This macro is only safe to call when $src and $dst are &[u8] and &mut [u8],
-/// respectively. The macro will panic if $src.len() != $size * $dst.len(),
-/// where $size represents the size of the integers encoded in $src.
-macro_rules! unsafe_read_slice {
-    ($src:expr, $dst:expr, $size:expr, $which:ident) => {{
-        assert_eq!($src.len(), $size * $dst.len());
-
-        unsafe {
-            copy_nonoverlapping(
-                $src.as_ptr(),
-                $dst.as_mut_ptr() as *mut u8,
-                $src.len(),
-            );
-        }
-        for v in $dst.iter_mut() {
-            *v = v.$which();
+/// Panics if $src.len() != $dst.len() * size_of::<$ty>().
+macro_rules! read_slice {
+    ($src:expr, $dst:expr, $ty:ty, $from_bytes:ident) => {{
+        const SIZE: usize = core::mem::size_of::<$ty>();
+        // Check types:
+        let src: &[u8] = $src;
+        let dst: &mut [$ty] = $dst;
+        assert_eq!(src.len(), dst.len() * SIZE);
+        for (src, dst) in src.chunks_exact(SIZE).zip(dst.iter_mut()) {
+            *dst = <$ty>::$from_bytes(src.try_into().unwrap());
         }
     }};
 }
@@ -2068,22 +2062,22 @@ impl ByteOrder for BigEndian {
 
     #[inline]
     fn read_u16_into(src: &[u8], dst: &mut [u16]) {
-        unsafe_read_slice!(src, dst, 2, to_be);
+        read_slice!(src, dst, u16, from_be_bytes);
     }
 
     #[inline]
     fn read_u32_into(src: &[u8], dst: &mut [u32]) {
-        unsafe_read_slice!(src, dst, 4, to_be);
+        read_slice!(src, dst, u32, from_be_bytes);
     }
 
     #[inline]
     fn read_u64_into(src: &[u8], dst: &mut [u64]) {
-        unsafe_read_slice!(src, dst, 8, to_be);
+        read_slice!(src, dst, u64, from_be_bytes);
     }
 
     #[inline]
     fn read_u128_into(src: &[u8], dst: &mut [u128]) {
-        unsafe_read_slice!(src, dst, 16, to_be);
+        read_slice!(src, dst, u128, from_be_bytes);
     }
 
     #[inline]
@@ -2268,22 +2262,22 @@ impl ByteOrder for LittleEndian {
 
     #[inline]
     fn read_u16_into(src: &[u8], dst: &mut [u16]) {
-        unsafe_read_slice!(src, dst, 2, to_le);
+        read_slice!(src, dst, u16, from_le_bytes);
     }
 
     #[inline]
     fn read_u32_into(src: &[u8], dst: &mut [u32]) {
-        unsafe_read_slice!(src, dst, 4, to_le);
+        read_slice!(src, dst, u32, from_le_bytes);
     }
 
     #[inline]
     fn read_u64_into(src: &[u8], dst: &mut [u64]) {
-        unsafe_read_slice!(src, dst, 8, to_le);
+        read_slice!(src, dst, u64, from_le_bytes);
     }
 
     #[inline]
     fn read_u128_into(src: &[u8], dst: &mut [u128]) {
-        unsafe_read_slice!(src, dst, 16, to_le);
+        read_slice!(src, dst, u128, from_le_bytes);
     }
 
     #[inline]


### PR DESCRIPTION
Rather than first copying data from source to destination buffer and
then performing endianess adjustment, to the conversion while copying.
This means that each byte is accessed only once which (according to
benchmarks) speeds up read_xxx_into and write_xxx_into methods:

    | Benchmark                      | Before [ns/iter] | After [ns/iter] |
    |--------------------------------+------------------+-----------------|
    | slice_i64::read_big_endian     |  34,863  (±  30) | 23,656  (± 935) |
    | slice_i64::read_little_endian  |  15,518  (±  19) | 13,362  (± 405) |
    | slice_i64::write_big_endian    |  30,910  (± 109) | 23,123  (±  91) |
    | slice_i64::write_little_endian |  14,924  (±  21) | 13,209  (± 180) |
    |--------------------------------+------------------+-----------------|
    | slice_u16::read_big_endian     |   7,492  (± 343) |  3,788  (±  16) |
    | slice_u16::read_little_endian  |   3,366  (±   8) |  3,198  (±   3) |
    | slice_u16::write_big_endian    |   4,066  (±   7) |  4,497  (±   8) |
    | slice_u16::write_little_endian |   4,040  (± 946) |  3,193  (±   7) |
    |--------------------------------+------------------+-----------------|
    | slice_u64::read_big_endian     |  35,816  (± 251) | 23,259  (±  21) |
    | slice_u64::read_little_endian  |  15,506  (±  86) | 13,365  (±  81) |
    | slice_u64::write_big_endian    |  30,948  (±  63) | 23,102  (±  36) |
    | slice_u64::write_little_endian |  14,938  (±  17) | 13,158  (±  18) |

The benchmarks were done on AMD Ryzen 9 5900X 12-Core Processor.

I’m somewhat confused why little endian benchmark show improvements
but the results are reproducible.  My best guess is that it’s
compiler failing to optimise out `for v $dst.iter_mut() { nop(); }`
loops currently present.
