### PR TITLE
Restore MSRV 1.41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         include:
         - build: pinned
           os: ubuntu-latest
-          rust: 1.60.0
+          rust: 1.41.0
         - build: stable
           os: ubuntu-latest
           rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ readme = "README.md"
 categories = ["encoding", "parsing", "no-std"]
 keywords = ["byte", "endian", "big-endian", "little-endian", "binary"]
 license = "Unlicense OR MIT"
-edition = "2021"
-rust-version = "1.60"
+edition = "2018"
 
 [lib]
 name = "byteorder"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ byteorder = { version = "1", default-features = false }
 
 ### Minimum Rust version policy
 
-This crate's minimum supported `rustc` version is `1.60.0`.
+This crate's minimum supported `rustc` version is `1.41.0`.
 
 The current policy is that the minimum Rust version required to use this crate
 can be increased in minor version updates. For example, if `crate 1.0` requires

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1206,7 +1206,8 @@ pub trait ByteOrder:
     #[inline]
     fn read_f32_into(src: &[u8], dst: &mut [f32]) {
         let dst = unsafe {
-            const _: () = assert!(align_of::<u32>() <= align_of::<f32>());
+            // Asserts `align_of::<u32>() <= align_of::<f32>()`
+            const _: () = [(); align_of::<f32>() + 1][align_of::<u32>()];
             slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u32, dst.len())
         };
         Self::read_u32_into(src, dst);
@@ -1268,7 +1269,8 @@ pub trait ByteOrder:
     #[inline]
     fn read_f64_into(src: &[u8], dst: &mut [f64]) {
         let dst = unsafe {
-            const _: () = assert!(align_of::<u64>() <= align_of::<f64>());
+            // Asserts `align_of::<u64>() <= align_of::<f64>()`
+            const _: () = [(); align_of::<f64>() + 1][align_of::<u64>()];
             slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
         };
         Self::read_u64_into(src, dst);


### PR DESCRIPTION
MSRV bump to 1.60 done in 1.5.0 has broke CI in RustCrypto. Some of our crates transitively dependent on `byteorder` have MSRV equal to 1.56. The bump was done for two simple static asserts which can be trivially worked around, so I think it's worth to revert the bump and restore the original MSRV equal to 1.41.