### PR TITLE
Avoid alignment-sensitive cast in `read_f64_into` on AIX

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1223,7 +1223,10 @@ pub trait ByteOrder:
         {
             let dst = unsafe {
                 const _: () = assert!(align_of::<u64>() <= align_of::<f64>());
-                slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
+                slice::from_raw_parts_mut(
+                    dst.as_mut_ptr() as *mut u64,
+                    dst.len(),
+                )
             };
             Self::read_u64_into(src, dst);
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,11 +1219,23 @@ pub trait ByteOrder:
     /// ```
     #[inline]
     fn read_f64_into(src: &[u8], dst: &mut [f64]) {
-        let dst = unsafe {
-            const _: () = assert!(align_of::<u64>() <= align_of::<f64>());
-            slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
-        };
-        Self::read_u64_into(src, dst);
+        #[cfg(not(target_os = "aix"))]
+        {
+            let dst = unsafe {
+                const _: () = assert!(align_of::<u64>() <= align_of::<f64>());
+                slice::from_raw_parts_mut(dst.as_mut_ptr() as *mut u64, dst.len())
+            };
+            Self::read_u64_into(src, dst);
+        }
+        #[cfg(target_os = "aix")]
+        {
+            // On AIX, `f64` may be less aligned than `u64`, so we cannot safely
+            // reinterpret `dst` as `&mut [u64]`.
+            const _: () = assert!(align_of::<f64>() <= align_of::<u64>());
+            for (s, d) in src.chunks_exact(8).zip(dst.iter_mut()) {
+                *d = Self::read_f64(s);
+            }
+        }
     }
 
     /// **DEPRECATED**.


### PR DESCRIPTION


`read_f64_into` currently reinterprets `&mut [f64]` as `&mut [u64]` after asserting that
`align_of::<u64>() <= align_of::<f64>()`. However, as mentioned in https://github.com/BurntSushi/byteorder/issues/221,
`u64` has a higher alignment than `f64` on AIX.

On AIX, this alignment assumption currently causes the function to assert, present when
building byteorder itself, or through crates that rely on byteorder as its dependency. An AIX-specific
workaround is added that decodes `f64` values element-by-element.

**Note:** It is understood that parts of the Rust ecosystem are already moving away from byteorder,
and that this PR may never be accepted upstream. That being said, I am posting this to both
document the issue on AIX and to provide users with a practical short-term way to keep compiling
byteorder and crates that depend on it.